### PR TITLE
Add: Webでの引用表示

### DIFF
--- a/app/controllers/api/v1/filters_controller.rb
+++ b/app/controllers/api/v1/filters_controller.rb
@@ -52,11 +52,11 @@ class Api::V1::FiltersController < Api::BaseController
   end
 
   def resource_params
-    params.permit(:phrase, :expires_in, :irreversible, :exclude_follows, :exclude_localusers, :whole_word, context: [])
+    params.permit(:phrase, :expires_in, :irreversible, :exclude_follows, :exclude_localusers, :with_quote, :whole_word, context: [])
   end
 
   def filter_params
-    resource_params.slice(:phrase, :expires_in, :irreversible, :exclude_follows, :exclude_localusers, :context)
+    resource_params.slice(:phrase, :expires_in, :irreversible, :exclude_follows, :exclude_localusers, :with_quote, :context)
   end
 
   def keyword_params

--- a/app/controllers/api/v1/statuses/emoji_reactions_controller.rb
+++ b/app/controllers/api/v1/statuses/emoji_reactions_controller.rb
@@ -31,7 +31,7 @@ class Api::V1::Statuses::EmojiReactionsController < Api::BaseController
     end
 
     render json: @status, serializer: REST::StatusSerializer, relationships: StatusRelationshipsPresenter.new(
-      [@status], current_account.id, emoji_reactions_map: { @status.id => false }
+      [@status], current_account.id
     )
   rescue Mastodon::NotPermittedError
     not_found

--- a/app/controllers/api/v2/filters_controller.rb
+++ b/app/controllers/api/v2/filters_controller.rb
@@ -43,6 +43,6 @@ class Api::V2::FiltersController < Api::BaseController
   end
 
   def resource_params
-    params.permit(:title, :expires_in, :filter_action, :exclude_follows, :exclude_localusers, context: [], keywords_attributes: [:id, :keyword, :whole_word, :_destroy])
+    params.permit(:title, :expires_in, :filter_action, :exclude_follows, :exclude_localusers, :with_quote, context: [], keywords_attributes: [:id, :keyword, :whole_word, :_destroy])
   end
 end

--- a/app/controllers/filters_controller.rb
+++ b/app/controllers/filters_controller.rb
@@ -49,7 +49,7 @@ class FiltersController < ApplicationController
   end
 
   def resource_params
-    params.require(:custom_filter).permit(:title, :expires_in, :filter_action, :exclude_follows, :exclude_localusers, context: [], keywords_attributes: [:id, :keyword, :whole_word, :_destroy])
+    params.require(:custom_filter).permit(:title, :expires_in, :filter_action, :exclude_follows, :exclude_localusers, :with_quote, context: [], keywords_attributes: [:id, :keyword, :whole_word, :_destroy])
   end
 
   def set_body_classes

--- a/app/javascript/mastodon/actions/importer/index.js
+++ b/app/javascript/mastodon/actions/importer/index.js
@@ -80,6 +80,10 @@ export function importFetchedStatuses(statuses) {
         processStatus(status.reblog);
       }
 
+      if (status.quote && status.quote.id) {
+        processStatus(status.quote);
+      }
+
       if (status.poll && status.poll.id) {
         pushUnique(polls, normalizePoll(status.poll, getState().getIn(['polls', status.poll.id])));
       }

--- a/app/javascript/mastodon/actions/importer/normalizer.js
+++ b/app/javascript/mastodon/actions/importer/normalizer.js
@@ -85,6 +85,11 @@ export function normalizeStatus(status, normalOldStatus) {
     normalStatus.spoiler_text = normalOldStatus.get('spoiler_text');
     normalStatus.hidden = normalOldStatus.get('hidden');
 
+    // for quoted post
+    if (!normalStatus.filtered && normalOldStatus.get('filtered')) {
+      normalStatus.filtered = normalOldStatus.get('filtered');
+    }
+
     if (normalOldStatus.get('translation')) {
       normalStatus.translation = normalOldStatus.get('translation');
     }

--- a/app/javascript/mastodon/components/compacted_status.jsx
+++ b/app/javascript/mastodon/components/compacted_status.jsx
@@ -342,6 +342,21 @@ class CompactedStatus extends ImmutablePureComponent {
       );
     }
 
+    if (status.get('quote_muted')) {
+      const minHandlers = {
+        moveUp: this.handleHotkeyMoveUp,
+        moveDown: this.handleHotkeyMoveDown,
+      };
+
+      return (
+        <HotKeys handlers={minHandlers}>
+          <div className='status__wrapper status__wrapper__compact status__wrapper--filtered focusable' tabIndex={0} ref={this.handleRef} onClick={this.handleClick}>
+            <FormattedMessage id='status.quote_filtered' defaultMessage='This quote is filtered because of muting, blocking or domain blocking' />
+          </div>
+        </HotKeys>
+      );
+    }
+
     isCardMediaWithSensitive = false;
 
     if (status.get('media_attachments').size > 0) {

--- a/app/javascript/mastodon/components/compacted_status.jsx
+++ b/app/javascript/mastodon/components/compacted_status.jsx
@@ -409,6 +409,7 @@ class CompactedStatus extends ImmutablePureComponent {
           <Bundle fetchComponent={MediaGallery} loading={this.renderLoadingMediaGallery}>
             {Component => (
               <Component
+                compact
                 media={status.get('media_attachments')}
                 lang={language}
                 sensitive={status.get('sensitive')}

--- a/app/javascript/mastodon/components/compacted_status.jsx
+++ b/app/javascript/mastodon/components/compacted_status.jsx
@@ -281,11 +281,6 @@ class CompactedStatus extends ImmutablePureComponent {
     this.handleToggleMediaVisibility();
   };
 
-  handleUnfilterClick = e => {
-    this.setState({ forceFilter: false });
-    e.preventDefault();
-  };
-
   _properStatus () {
     const { status } = this.props;
 
@@ -335,26 +330,6 @@ class CompactedStatus extends ImmutablePureComponent {
     const connectUp = previousId && previousId === status.get('in_reply_to_id');
     const connectToRoot = rootId && rootId === status.get('in_reply_to_id');
     const connectReply = nextInReplyToId && nextInReplyToId === status.get('id');
-    const matchedFilters = status.get('matched_filters');
-
-    if (this.state.forceFilter === undefined ? matchedFilters : this.state.forceFilter) {
-      const minHandlers = this.props.muted ? {} : {
-        moveUp: this.handleHotkeyMoveUp,
-        moveDown: this.handleHotkeyMoveDown,
-      };
-
-      return (
-        <HotKeys handlers={minHandlers}>
-          <div className='status__wrapper status__wrapper--filtered focusable' tabIndex={0} ref={this.handleRef}>
-            <FormattedMessage id='status.filtered' defaultMessage='Filtered' />: {matchedFilters.join(', ')}.
-            {' '}
-            <button className='status__wrapper--filtered__button' onClick={this.handleUnfilterClick}>
-              <FormattedMessage id='status.show_filter_reason' defaultMessage='Show anyway' />
-            </button>
-          </div>
-        </HotKeys>
-      );
-    }
 
     if (showThread && status.get('in_reply_to_id') && status.get('in_reply_to_account_id') === status.getIn(['account', 'id'])) {
       const display_name_html = { __html: status.getIn(['account', 'display_name_html']) };

--- a/app/javascript/mastodon/components/compacted_status.jsx
+++ b/app/javascript/mastodon/components/compacted_status.jsx
@@ -350,6 +350,7 @@ class CompactedStatus extends ImmutablePureComponent {
 
       return (
         <HotKeys handlers={minHandlers}>
+          {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
           <div className='status__wrapper status__wrapper__compact status__wrapper--filtered focusable' tabIndex={0} ref={this.handleRef} onClick={this.handleClick}>
             <FormattedMessage id='status.quote_filtered' defaultMessage='This quote is filtered because of muting, blocking or domain blocking' />
           </div>

--- a/app/javascript/mastodon/components/compacted_status.jsx
+++ b/app/javascript/mastodon/components/compacted_status.jsx
@@ -86,21 +86,8 @@ class CompactedStatus extends ImmutablePureComponent {
     nextInReplyToId: PropTypes.string,
     rootId: PropTypes.string,
     onClick: PropTypes.func,
-    onReply: PropTypes.func,
-    onFavourite: PropTypes.func,
-    onEmojiReact: PropTypes.func,
-    onUnEmojiReact: PropTypes.func,
-    onReblog: PropTypes.func,
-    onReblogForceModal: PropTypes.func,
-    onDelete: PropTypes.func,
-    onDirect: PropTypes.func,
-    onMention: PropTypes.func,
-    onPin: PropTypes.func,
     onOpenMedia: PropTypes.func,
     onOpenVideo: PropTypes.func,
-    onBlock: PropTypes.func,
-    onAddFilter: PropTypes.func,
-    onEmbed: PropTypes.func,
     onHeightChange: PropTypes.func,
     onToggleHidden: PropTypes.func,
     onToggleCollapsed: PropTypes.func,
@@ -116,7 +103,6 @@ class CompactedStatus extends ImmutablePureComponent {
     updateScrollBottom: PropTypes.func,
     cacheMediaWidth: PropTypes.func,
     cachedMediaWidth: PropTypes.number,
-    withoutEmojiReactions: PropTypes.bool,
   };
 
   // Avoid checking props that are functions (and whose equality will always
@@ -248,24 +234,6 @@ class CompactedStatus extends ImmutablePureComponent {
     }
   };
 
-  handleHotkeyReply = e => {
-    e.preventDefault();
-    this.props.onReply(this._properStatus(), this.context.router.history);
-  };
-
-  handleHotkeyFavourite = () => {
-    this.props.onFavourite(this._properStatus());
-  };
-
-  handleHotkeyBoost = e => {
-    this.props.onReblog(this._properStatus(), e);
-  };
-
-  handleHotkeyMention = e => {
-    e.preventDefault();
-    this.props.onMention(this._properStatus().get('account'), this.context.router.history);
-  };
-
   handleHotkeyOpen = () => {
     if (this.props.onClick) {
       this.props.onClick();
@@ -342,10 +310,6 @@ class CompactedStatus extends ImmutablePureComponent {
     }
 
     const handlers = this.props.muted ? {} : {
-      reply: this.handleHotkeyReply,
-      favourite: this.handleHotkeyFavourite,
-      boost: this.handleHotkeyBoost,
-      mention: this.handleHotkeyMention,
       open: this.handleHotkeyOpen,
       openProfile: this.handleHotkeyOpenProfile,
       moveUp: this.handleHotkeyMoveUp,
@@ -355,7 +319,7 @@ class CompactedStatus extends ImmutablePureComponent {
       openMedia: this.handleHotkeyOpenMedia,
     };
 
-    let media, isCardMediaWithSensitive, statusAvatar, prepend, rebloggedByText;
+    let media, isCardMediaWithSensitive, prepend, rebloggedByText;
 
     if (hidden) {
       return (
@@ -392,21 +356,7 @@ class CompactedStatus extends ImmutablePureComponent {
       );
     }
 
-    if (featured) {
-      prepend = (
-        <div className='status__prepend'>
-          <div className='status__prepend-icon-wrapper'><Icon id='thumb-tack' className='status__prepend-icon' fixedWidth /></div>
-          <FormattedMessage id='status.pinned' defaultMessage='Pinned post' />
-        </div>
-      );
-    } else if (status.get('visibility') === 'direct') {
-      prepend = (
-        <div className='status__prepend'>
-          <div className='status__prepend-icon-wrapper'><Icon id='at' className='status__prepend-icon' fixedWidth /></div>
-          <FormattedMessage id='status.direct_indicator' defaultMessage='Private mention' />
-        </div>
-      );
-    } else if (showThread && status.get('in_reply_to_id') && status.get('in_reply_to_account_id') === status.getIn(['account', 'id'])) {
+    if (showThread && status.get('in_reply_to_id') && status.get('in_reply_to_account_id') === status.getIn(['account', 'id'])) {
       const display_name_html = { __html: status.getIn(['account', 'display_name_html']) };
 
       prepend = (
@@ -510,8 +460,6 @@ class CompactedStatus extends ImmutablePureComponent {
       isCardMediaWithSensitive = status.get('spoiler_text').length > 0;
     }
 
-    statusAvatar = <Avatar account={status.get('account')} size={24} inline />;
-
     const {statusContentProps, hashtagBar} = getHashtagBarForStatus(status);
     const expanded = !status.get('hidden') || status.get('spoiler_text').length === 0;
 
@@ -531,7 +479,7 @@ class CompactedStatus extends ImmutablePureComponent {
 
               <a onClick={this.handleAccountClick} href={`/@${status.getIn(['account', 'acct'])}`} title={status.getIn(['account', 'acct'])} className='status__display-name' target='_blank' rel='noopener noreferrer'>
                 <div className='status__avatar status__avatar__compact'>
-                  {statusAvatar}
+                  <Avatar account={status.get('account')} size={24} inline />
                 </div>
 
                 <DisplayName account={status.get('account')} />

--- a/app/javascript/mastodon/components/media_gallery.jsx
+++ b/app/javascript/mastodon/components/media_gallery.jsx
@@ -236,6 +236,7 @@ class MediaGallery extends PureComponent {
     visible: PropTypes.bool,
     autoplay: PropTypes.bool,
     onToggleVisibility: PropTypes.func,
+    compact: PropTypes.bool,
   };
 
   state = {
@@ -306,7 +307,7 @@ class MediaGallery extends PureComponent {
   }
 
   render () {
-    const { media, lang, intl, sensitive, defaultWidth, autoplay } = this.props;
+    const { media, lang, intl, sensitive, defaultWidth, autoplay, compact } = this.props;
     const { visible } = this.state;
     const width = this.state.width || defaultWidth;
 
@@ -359,9 +360,10 @@ class MediaGallery extends PureComponent {
     const columnClass = (size === 9) ? 'media-gallery--column3' :
       (size === 10 || size === 11 || size === 12 || size === 13 || size === 14 || size === 15 || size === 16) ? 'media-gallery--column4' :
       'media-gallery--column2';
+    const compactClass = compact ? 'media-gallery__compact' : null;
 
     return (
-      <div className={classNames('media-gallery', rowClass, columnClass)} style={style} ref={this.handleRef}>
+      <div className={classNames('media-gallery', rowClass, columnClass, compactClass)} style={style} ref={this.handleRef}>
         <div className={classNames('spoiler-button', { 'spoiler-button--minified': visible && !uncached, 'spoiler-button--click-thru': uncached })}>
           {spoilerButton}
         </div>

--- a/app/javascript/mastodon/components/status.jsx
+++ b/app/javascript/mastodon/components/status.jsx
@@ -413,11 +413,51 @@ class Status extends ImmutablePureComponent {
 
     let visibilityIcon = visibilityIconInfo[status.get('limited_scope') || status.get('visibility_ex')] || visibilityIconInfo[status.get('visibility')];
 
+    if (account === undefined || account === null) {
+      statusAvatar = <Avatar account={status.get('account')} size={46} />;
+    } else {
+      statusAvatar = <AvatarOverlay account={status.get('account')} friend={account} />;
+    }
+
     if (this.state.forceFilter === undefined ? matchedFilters : this.state.forceFilter) {
       const minHandlers = muted ? {} : {
         moveUp: this.handleHotkeyMoveUp,
         moveDown: this.handleHotkeyMoveDown,
       };
+
+      if (status.get('filter_action') === 'half_warn') {
+        return (
+          <HotKeys handlers={minHandlers}>
+            <div className='status__wrapper status__wrapper--filtered focusable' tabIndex={0} ref={this.handleRef}>
+              <div onClick={this.handleClick} className='status__info'>
+                <a href={`/@${status.getIn(['account', 'acct'])}/${status.get('id')}`} className='status__relative-time' target='_blank' rel='noopener noreferrer'>
+                  {withReference}
+                  {withExpiration}
+                  {withLimited}
+                  <span className='status__visibility-icon'><Icon id={visibilityIcon.icon} title={visibilityIcon.text} /></span>
+                  <RelativeTimestamp timestamp={status.get('created_at')} />{status.get('edited_at') && <abbr title={intl.formatMessage(messages.edited, { date: intl.formatDate(status.get('edited_at'), { hour12: false, year: 'numeric', month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit' }) })}> *</abbr>}
+                </a>
+
+                <a onClick={this.handleAccountClick} href={`/@${status.getIn(['account', 'acct'])}`} title={status.getIn(['account', 'acct'])} className='status__display-name' target='_blank' rel='noopener noreferrer'>
+                  <div className='status__avatar'>
+                    {statusAvatar}
+                  </div>
+
+                  <DisplayName account={status.get('account')} />
+                </a>
+              </div>
+
+              <div >
+                  <FormattedMessage id='status.filtered' defaultMessage='Filtered' />: {matchedFilters.join(', ')}.
+                  {' '}
+                  <button className='status__wrapper--filtered__button' onClick={this.handleUnfilterClick}>
+                    <FormattedMessage id='status.show_filter_reason' defaultMessage='Show anyway' />
+                  </button>
+                </div>
+            </div>
+          </HotKeys>
+        );
+      }
 
       return (
         <HotKeys handlers={minHandlers}>
@@ -567,12 +607,6 @@ class Status extends ImmutablePureComponent {
         />
       );
       isCardMediaWithSensitive = status.get('spoiler_text').length > 0;
-    }
-
-    if (account === undefined || account === null) {
-      statusAvatar = <Avatar account={status.get('account')} size={46} />;
-    } else {
-      statusAvatar = <AvatarOverlay account={status.get('account')} friend={account} />;
     }
 
     visibilityIcon = visibilityIconInfo[status.get('limited_scope') || status.get('visibility_ex')] || visibilityIconInfo[status.get('visibility')];

--- a/app/javascript/mastodon/components/status.jsx
+++ b/app/javascript/mastodon/components/status.jsx
@@ -13,6 +13,7 @@ import AttachmentList from 'mastodon/components/attachment_list';
 import { Icon }  from 'mastodon/components/icon';
 import PictureInPicturePlaceholder from 'mastodon/components/picture_in_picture_placeholder';
 
+import CompactedStatusContainer from '../containers/compacted_status_container'
 import Card from '../features/status/components/card';
 // We use the component (and not the container) since we do not want
 // to use the progress bar to show download progress
@@ -22,7 +23,6 @@ import { displayMedia, enableEmojiReaction, showEmojiReactionOnTimeline } from '
 
 import { Avatar } from './avatar';
 import { AvatarOverlay } from './avatar_overlay';
-import CompactedStatus from './compacted_status';
 import { DisplayName } from './display_name';
 import { getHashtagBarForStatus } from './hashtag_bar';
 import { RelativeTimestamp } from './relative_timestamp';
@@ -630,7 +630,7 @@ class Status extends ImmutablePureComponent {
               {...statusContentProps}
             />
 
-            <CompactedStatus status={status} onToggleCollapsed={this.props.onToggleCollapsed} />
+            <CompactedStatusContainer id={status.get('id')} />
 
             {(!isCardMediaWithSensitive || !status.get('hidden')) && media}
 

--- a/app/javascript/mastodon/components/status.jsx
+++ b/app/javascript/mastodon/components/status.jsx
@@ -624,7 +624,8 @@ class Status extends ImmutablePureComponent {
     const expanded = !status.get('hidden') || status.get('spoiler_text').length === 0;
 
     const withLimited = status.get('visibility_ex') === 'limited' && status.get('limited_scope') ? <span className='status__visibility-icon'><Icon id='get-pocket' title='Limited' /></span> : null;
-    const withReference = status.get('status_references_count') > 0 ? <span className='status__visibility-icon'><Icon id='link' title='Reference' /></span> : null;
+    const withQuote = status.get('quote_id') ? <span className='status__visibility-icon'><Icon id='quote-right' title='Quote' /></span> : null;
+    const withReference = (!withQuote && status.get('status_references_count') > 0) ? <span className='status__visibility-icon'><Icon id='link' title='Reference' /></span> : null;
     const withExpiration = status.get('expires_at') ? <span className='status__visibility-icon'><Icon id='clock-o' title='Expiration' /></span> : null;
 
     const quote = !muted && status.get('quote_id') && <CompactedStatusContainer id={status.get('quote_id')} />
@@ -640,6 +641,7 @@ class Status extends ImmutablePureComponent {
             {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
             <div onClick={this.handleClick} className='status__info'>
               <a href={`/@${status.getIn(['account', 'acct'])}/${status.get('id')}`} className='status__relative-time' target='_blank' rel='noopener noreferrer'>
+                {withQuote}
                 {withReference}
                 {withExpiration}
                 {withLimited}

--- a/app/javascript/mastodon/components/status.jsx
+++ b/app/javascript/mastodon/components/status.jsx
@@ -19,7 +19,7 @@ import Card from '../features/status/components/card';
 // to use the progress bar to show download progress
 import Bundle from '../features/ui/components/bundle';
 import { MediaGallery, Video, Audio } from '../features/ui/util/async-components';
-import { displayMedia, enableEmojiReaction, showEmojiReactionOnTimeline } from '../initial_state';
+import { displayMedia, enableEmojiReaction, showEmojiReactionOnTimeline, showQuoteInHome, showQuoteInPublic } from '../initial_state';
 
 import { Avatar } from './avatar';
 import { AvatarOverlay } from './avatar_overlay';
@@ -88,6 +88,7 @@ class Status extends ImmutablePureComponent {
   static propTypes = {
     status: ImmutablePropTypes.map,
     account: ImmutablePropTypes.map,
+    contextType: PropTypes.string,
     previousId: PropTypes.string,
     nextInReplyToId: PropTypes.string,
     rootId: PropTypes.string,
@@ -361,6 +362,8 @@ class Status extends ImmutablePureComponent {
     const { intl, hidden, featured, unread, muted, showThread, scrollKey, pictureInPicture, previousId, nextInReplyToId, rootId } = this.props;
 
     let { status, account, ...other } = this.props;
+    
+    const contextType = (this.props.contextType || '').split(':')[0];
 
     if (status === null) {
       return null;
@@ -628,7 +631,7 @@ class Status extends ImmutablePureComponent {
     const withReference = (!withQuote && status.get('status_references_count') > 0) ? <span className='status__visibility-icon'><Icon id='link' title='Reference' /></span> : null;
     const withExpiration = status.get('expires_at') ? <span className='status__visibility-icon'><Icon id='clock-o' title='Expiration' /></span> : null;
 
-    const quote = !muted && status.get('quote_id') && <CompactedStatusContainer id={status.get('quote_id')} />
+    const quote = !muted && status.get('quote_id') && (['public', 'community'].includes(contextType) ? showQuoteInPublic : showQuoteInHome) && <CompactedStatusContainer id={status.get('quote_id')} />
 
     return (
       <HotKeys handlers={handlers}>
@@ -669,7 +672,7 @@ class Status extends ImmutablePureComponent {
               {...statusContentProps}
             />
 
-            {quote}
+            {(!status.get('spoiler_text') || expanded) && quote}
 
             {(!isCardMediaWithSensitive || !status.get('hidden')) && media}
 

--- a/app/javascript/mastodon/components/status.jsx
+++ b/app/javascript/mastodon/components/status.jsx
@@ -429,6 +429,7 @@ class Status extends ImmutablePureComponent {
         return (
           <HotKeys handlers={minHandlers}>
             <div className='status__wrapper status__wrapper--filtered focusable' tabIndex={0} ref={this.handleRef}>
+              {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
               <div onClick={this.handleClick} className='status__info'>
                 <a href={`/@${status.getIn(['account', 'acct'])}/${status.get('id')}`} className='status__relative-time' target='_blank' rel='noopener noreferrer'>
                   {withReference}

--- a/app/javascript/mastodon/components/status.jsx
+++ b/app/javascript/mastodon/components/status.jsx
@@ -358,7 +358,7 @@ class Status extends ImmutablePureComponent {
   };
 
   render () {
-    const { intl, hidden, featured, unread, showThread, scrollKey, pictureInPicture, previousId, nextInReplyToId, rootId } = this.props;
+    const { intl, hidden, featured, unread, muted, showThread, scrollKey, pictureInPicture, previousId, nextInReplyToId, rootId } = this.props;
 
     let { status, account, ...other } = this.props;
 
@@ -366,7 +366,7 @@ class Status extends ImmutablePureComponent {
       return null;
     }
 
-    const handlers = this.props.muted ? {} : {
+    const handlers = muted ? {} : {
       reply: this.handleHotkeyReply,
       favourite: this.handleHotkeyFavourite,
       boost: this.handleHotkeyBoost,
@@ -385,7 +385,7 @@ class Status extends ImmutablePureComponent {
     if (hidden) {
       return (
         <HotKeys handlers={handlers}>
-          <div ref={this.handleRef} className={classNames('status__wrapper', { focusable: !this.props.muted })} tabIndex={0}>
+          <div ref={this.handleRef} className={classNames('status__wrapper', { focusable: !muted })} tabIndex={0}>
             <span>{status.getIn(['account', 'display_name']) || status.getIn(['account', 'username'])}</span>
             <span>{status.get('content')}</span>
           </div>
@@ -414,7 +414,7 @@ class Status extends ImmutablePureComponent {
     let visibilityIcon = visibilityIconInfo[status.get('limited_scope') || status.get('visibility_ex')] || visibilityIconInfo[status.get('visibility')];
 
     if (this.state.forceFilter === undefined ? matchedFilters : this.state.forceFilter) {
-      const minHandlers = this.props.muted ? {} : {
+      const minHandlers = muted ? {} : {
         moveUp: this.handleHotkeyMoveUp,
         moveDown: this.handleHotkeyMoveDown,
       };
@@ -479,7 +479,7 @@ class Status extends ImmutablePureComponent {
     } else if (status.get('media_attachments').size > 0) {
       const language = status.getIn(['translation', 'language']) || status.get('language');
 
-      if (this.props.muted) {
+      if (muted) {
         media = (
           <AttachmentList
             compact
@@ -557,7 +557,7 @@ class Status extends ImmutablePureComponent {
           </Bundle>
         );
       }
-    } else if (status.get('card') && !this.props.muted) {
+    } else if (status.get('card') && !muted) {
       media = (
         <Card
           onOpenMedia={this.handleOpenMedia}
@@ -592,12 +592,14 @@ class Status extends ImmutablePureComponent {
     const withReference = status.get('status_references_count') > 0 ? <span className='status__visibility-icon'><Icon id='link' title='Reference' /></span> : null;
     const withExpiration = status.get('expires_at') ? <span className='status__visibility-icon'><Icon id='clock-o' title='Expiration' /></span> : null;
 
+    const quote = !muted && status.get('quote_id') && <CompactedStatusContainer id={status.get('quote_id')} />
+
     return (
       <HotKeys handlers={handlers}>
-        <div className={classNames('status__wrapper', `status__wrapper-${status.get('visibility_ex')}`, { 'status__wrapper-reply': !!status.get('in_reply_to_id'), unread, focusable: !this.props.muted })} tabIndex={this.props.muted ? null : 0} data-featured={featured ? 'true' : null} aria-label={textForScreenReader(intl, status, rebloggedByText)} ref={this.handleRef} data-nosnippet={status.getIn(['account', 'noindex'], true) || undefined}>
+        <div className={classNames('status__wrapper', `status__wrapper-${status.get('visibility_ex')}`, { 'status__wrapper-reply': !!status.get('in_reply_to_id'), unread, focusable: !muted })} tabIndex={muted ? null : 0} data-featured={featured ? 'true' : null} aria-label={textForScreenReader(intl, status, rebloggedByText)} ref={this.handleRef} data-nosnippet={status.getIn(['account', 'noindex'], true) || undefined}>
           {prepend}
 
-          <div className={classNames('status', `status-${status.get('visibility_ex')}`, { 'status-reply': !!status.get('in_reply_to_id'), 'status--in-thread': !!rootId, 'status--first-in-thread': previousId && (!connectUp || connectToRoot), muted: this.props.muted })} data-id={status.get('id')}>
+          <div className={classNames('status', `status-${status.get('visibility_ex')}`, { 'status-reply': !!status.get('in_reply_to_id'), 'status--in-thread': !!rootId, 'status--first-in-thread': previousId && (!connectUp || connectToRoot), muted: muted })} data-id={status.get('id')}>
             {(connectReply || connectUp || connectToRoot) && <div className={classNames('status__line', { 'status__line--full': connectReply, 'status__line--first': !status.get('in_reply_to_id') && !connectToRoot })} />}
 
             {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
@@ -630,7 +632,7 @@ class Status extends ImmutablePureComponent {
               {...statusContentProps}
             />
 
-            <CompactedStatusContainer id={status.get('id')} />
+            {quote}
 
             {(!isCardMediaWithSensitive || !status.get('hidden')) && media}
 

--- a/app/javascript/mastodon/components/status_action_bar.jsx
+++ b/app/javascript/mastodon/components/status_action_bar.jsx
@@ -298,6 +298,7 @@ class StatusActionBar extends ImmutablePureComponent {
     const account            = status.get('account');
     const writtenByMe        = status.getIn(['account', 'id']) === me;
     const isRemote           = status.getIn(['account', 'username']) !== status.getIn(['account', 'acct']);
+    const allowQuote         = status.getIn(['account', 'other_settings', 'allow_quote']);
 
     let menu = [];
 
@@ -332,7 +333,10 @@ class StatusActionBar extends ImmutablePureComponent {
 
       if (publicStatus) {
         menu.push({ text: intl.formatMessage(messages.reference), action: this.handleReference });
-        menu.push({ text: intl.formatMessage(messages.quote), action: this.handleQuote });
+
+        if (allowQuote) {
+          menu.push({ text: intl.formatMessage(messages.quote), action: this.handleQuote });
+        }
       }
 
       menu.push({ text: intl.formatMessage(status.get('bookmarked') ? messages.removeBookmark : messages.bookmark), action: this.handleBookmarkClickOriginal });

--- a/app/javascript/mastodon/containers/compacted_status_container.jsx
+++ b/app/javascript/mastodon/containers/compacted_status_container.jsx
@@ -1,0 +1,78 @@
+import { injectIntl } from 'react-intl';
+
+import { connect } from 'react-redux';
+
+import { openModal } from '../actions/modal';
+import {
+  hideStatus,
+  revealStatus,
+  toggleStatusCollapse,
+  translateStatus,
+  undoStatusTranslation,
+} from '../actions/statuses';
+import CompactedStatus from '../components/compacted_status';
+import { makeGetStatus, makeGetPictureInPicture } from '../selectors';
+
+const makeMapStateToProps = () => {
+  const getStatus = makeGetStatus();
+  const getPictureInPicture = makeGetPictureInPicture();
+
+  const mapStateToProps = (state, props) => ({
+    status: getStatus(state, props),
+    nextInReplyToId: props.nextId ? state.getIn(['statuses', props.nextId, 'in_reply_to_id']) : null,
+    pictureInPicture: getPictureInPicture(state, props),
+  });
+
+  return mapStateToProps;
+};
+
+const mapDispatchToProps = (dispatch) => ({
+
+  onTranslate (status) {
+    if (status.get('translation')) {
+      dispatch(undoStatusTranslation(status.get('id'), status.get('poll')));
+    } else {
+      dispatch(translateStatus(status.get('id')));
+    }
+  },
+
+  onOpenMedia (statusId, media, index, lang) {
+    dispatch(openModal({
+      modalType: 'MEDIA',
+      modalProps: { statusId, media, index, lang },
+    }));
+  },
+
+  onOpenVideo (statusId, media, lang, options) {
+    dispatch(openModal({
+      modalType: 'VIDEO',
+      modalProps: { statusId, media, lang, options },
+    }));
+  },
+
+  onToggleHidden (status) {
+    if (status.get('hidden')) {
+      dispatch(revealStatus(status.get('id')));
+    } else {
+      dispatch(hideStatus(status.get('id')));
+    }
+  },
+
+  onToggleCollapsed (status, isCollapsed) {
+    dispatch(toggleStatusCollapse(status.get('id'), isCollapsed));
+  },
+
+  onInteractionModal (type, status) {
+    dispatch(openModal({
+      modalType: 'INTERACTION',
+      modalProps: {
+        type,
+        accountId: status.getIn(['account', 'id']),
+        url: status.get('uri'),
+      },
+    }));
+  },
+
+});
+
+export default injectIntl(connect(makeMapStateToProps, mapDispatchToProps)(CompactedStatus));

--- a/app/javascript/mastodon/containers/status_container.jsx
+++ b/app/javascript/mastodon/containers/status_container.jsx
@@ -80,6 +80,8 @@ const makeMapStateToProps = () => {
 
 const mapDispatchToProps = (dispatch, { intl, contextType }) => ({
 
+  contextType,
+
   onReply (status, router) {
     dispatch((_, getState) => {
       let state = getState();

--- a/app/javascript/mastodon/features/status/components/action_bar.jsx
+++ b/app/javascript/mastodon/features/status/components/action_bar.jsx
@@ -236,6 +236,7 @@ class ActionBar extends PureComponent {
     const account            = status.get('account');
     const writtenByMe        = status.getIn(['account', 'id']) === me;
     const isRemote           = status.getIn(['account', 'username']) !== status.getIn(['account', 'acct']);
+    const allowQuote         = status.getIn(['account', 'other_settings', 'allow_quote']);
 
     let menu = [];
 
@@ -259,7 +260,10 @@ class ActionBar extends PureComponent {
 
       if (publicStatus) {
         menu.push({ text: intl.formatMessage(messages.reference), action: this.handleReference });
-        menu.push({ text: intl.formatMessage(messages.quote), action: this.handleQuote });
+
+        if (allowQuote) {
+          menu.push({ text: intl.formatMessage(messages.quote), action: this.handleQuote });
+        }
       }
       menu.push({ text: intl.formatMessage(messages.bookmark_category), action: this.handleBookmarkCategoryAdderClick });
 

--- a/app/javascript/mastodon/initial_state.js
+++ b/app/javascript/mastodon/initial_state.js
@@ -64,6 +64,7 @@
  * @property {boolean} enable_local_privacy
  * @property {boolean} enable_dtl_menu
  * @property {boolean=} expand_spoilers
+ * @property {boolean} hide_blocking_quote
  * @property {boolean} hide_recent_emojis
  * @property {boolean} limited_federation_mode
  * @property {string} locale
@@ -138,6 +139,7 @@ export const enableLoginPrivacy = getMeta('enable_login_privacy');
 export const enableDtlMenu = getMeta('enable_dtl_menu');
 export const expandSpoilers = getMeta('expand_spoilers');
 export const forceSingleColumn = !getMeta('advanced_layout');
+export const hideBlockingQuote = getMeta('hide_blocking_quote');
 export const hideRecentEmojis = getMeta('hide_recent_emojis');
 export const limitedFederationMode = getMeta('limited_federation_mode');
 export const mascot = getMeta('mascot');

--- a/app/javascript/mastodon/initial_state.js
+++ b/app/javascript/mastodon/initial_state.js
@@ -78,6 +78,8 @@
  * @property {boolean} search_enabled
  * @property {boolean} trends_enabled
  * @property {boolean} show_emoji_reaction_on_timeline
+ * @property {boolean} show_quote_in_home
+ * @property {boolean} show_quote_in_public
  * @property {string} simple_timeline_menu
  * @property {boolean} single_user_mode
  * @property {string} source_url
@@ -149,6 +151,8 @@ export const repository = getMeta('repository');
 export const searchEnabled = getMeta('search_enabled');
 export const trendsEnabled = getMeta('trends_enabled');
 export const showEmojiReactionOnTimeline = getMeta('show_emoji_reaction_on_timeline');
+export const showQuoteInHome = getMeta('show_quote_in_home');
+export const showQuoteInPublic = getMeta('show_quote_in_public');
 export const showTrends = getMeta('show_trends');
 export const simpleTimelineMenu = getMeta('simple_timeline_menu');
 export const singleUserMode = getMeta('single_user_mode');

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -692,7 +692,7 @@
   "status.open": "Expand this post",
   "status.pin": "Pin on profile",
   "status.pinned": "Pinned post",
-  "status.quote": "Ref (quote in other servers)",
+  "status.quote": "Quote",
   "status.read_more": "Read more",
   "status.reblog": "Boost",
   "status.reblog_private": "Boost with original visibility",

--- a/app/javascript/mastodon/locales/ja.json
+++ b/app/javascript/mastodon/locales/ja.json
@@ -778,7 +778,7 @@
   "status.open": "詳細を表示",
   "status.pin": "プロフィールに固定表示",
   "status.pinned": "固定された投稿",
-  "status.quote": "参照 (他サーバーで引用扱い)",
+  "status.quote": "引用",
   "status.read_more": "もっと見る",
   "status.reblog": "ブースト",
   "status.reblog_private": "ブースト",

--- a/app/javascript/mastodon/selectors/index.js
+++ b/app/javascript/mastodon/selectors/index.js
@@ -3,7 +3,7 @@ import { createSelector } from 'reselect';
 
 import { toServerSideType } from 'mastodon/utils/filters';
 
-import { me } from '../initial_state';
+import { me, hideBlockingQuote } from '../initial_state';
 
 const getAccountBase         = (state, id) => state.getIn(['accounts', id], null);
 const getAccountCounters     = (state, id) => state.getIn(['accounts_counters', id], null);
@@ -51,6 +51,10 @@ export const makeGetStatus = () => {
         statusReblog = statusReblog.set('account', accountReblog);
       } else {
         statusReblog = null;
+      }
+
+      if (hideBlockingQuote && statusBase.getIn(['quote', 'quote_muted'])) {
+        return null;
       }
 
       let filtered = false;

--- a/app/javascript/mastodon/selectors/index.js
+++ b/app/javascript/mastodon/selectors/index.js
@@ -54,6 +54,7 @@ export const makeGetStatus = () => {
       }
 
       let filtered = false;
+      let filterAction = 'warn';
       if ((accountReblog || accountBase).get('id') !== me && filters) {
         let filterResults = statusReblog?.get('filtered') || statusBase.get('filtered') || ImmutableList();
         if (filterResults.some((result) => filters.getIn([result.get('filter'), 'filter_action']) === 'hide')) {
@@ -62,6 +63,7 @@ export const makeGetStatus = () => {
         filterResults = filterResults.filter(result => filters.has(result.get('filter')));
         if (!filterResults.isEmpty()) {
           filtered = filterResults.map(result => filters.getIn([result.get('filter'), 'title']));
+          filterAction = filterResults.some((result) => filters.getIn([result.get('filter'), 'filter_action']) === 'warn') ? 'warn' : 'half_warn';
         }
       }
 
@@ -69,6 +71,7 @@ export const makeGetStatus = () => {
         map.set('reblog', statusReblog);
         map.set('account', accountBase);
         map.set('matched_filters', filtered);
+        map.set('filter_action', filterAction);
       });
     },
   );

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -8490,7 +8490,7 @@ noscript {
 
   &.status__wrapper__compact {
     border-radius: 4px;
-    border: 1px solid $base-border-color;
+    border: 1px solid $ui-primary-color;
     margin-block-start: 16px;
     cursor: pointer;
   }

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -8492,6 +8492,7 @@ noscript {
     border-radius: 4px;
     border: 1px solid $base-border-color;
     margin-block-start: 16px;
+    cursor: pointer;
   }
 
   &.unread {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1733,6 +1733,11 @@ a.account__display-name {
 .status__avatar {
   width: 46px;
   height: 46px;
+
+  &.status__avatar__compact {
+    width: 24px;
+    height: 24px;
+  }
 }
 
 .muted {
@@ -8478,6 +8483,12 @@ noscript {
 .notification,
 .status__wrapper {
   position: relative;
+
+  &.status__wrapper__compact {
+    border-radius: 4px;
+    border: 1px solid $base-border-color;
+    margin-block-start: 16px;
+  }
 
   &.unread {
     &::before {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -6524,7 +6524,7 @@ a.status-card {
   position: relative;
   width: 100%;
   min-height: 64px;
-  max-height: 70vh;
+  max-height: 60vh;
   display: grid;
   grid-template-columns: 50% 50%;
   grid-template-rows: 50% 50%;
@@ -6544,6 +6544,10 @@ a.status-card {
 
   &--column4 {
     grid-template-columns: 25% 25% 25% 25%;
+  }
+
+  &__compact {
+    max-height: 24vh;
   }
 }
 

--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -486,9 +486,8 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
   def process_references!
     references = @object['references'].nil? ? [] : ActivityPub::FetchReferencesService.new.call(@status, @object['references'])
     quote = @object['quote'] || @object['quoteUrl'] || @object['quoteURL'] || @object['_misskey_quote']
-    references << quote if quote
 
-    ProcessReferencesService.perform_worker_async(@status, [], references)
+    ProcessReferencesService.perform_worker_async(@status, [], references, [quote].compact)
   end
 
   def join_group!

--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -444,7 +444,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
 
   def related_to_local_activity?
     fetch? || followed_by_local_accounts? || requested_through_relay? ||
-      responds_to_followed_account? || addresses_local_accounts?
+      responds_to_followed_account? || addresses_local_accounts? || quote_local?
   end
 
   def responds_to_followed_account?
@@ -485,9 +485,22 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
 
   def process_references!
     references = @object['references'].nil? ? [] : ActivityPub::FetchReferencesService.new.call(@status, @object['references'])
-    quote = @object['quote'] || @object['quoteUrl'] || @object['quoteURL'] || @object['_misskey_quote']
 
     ProcessReferencesService.perform_worker_async(@status, [], references, [quote].compact)
+  end
+
+  def quote_local?
+    url = quote
+
+    if url.present?
+      ResolveURLService.new.call(url, on_behalf_of: @account, local_only: true).present?
+    else
+      false
+    end
+  end
+
+  def quote
+    @quote ||= @object['quote'] || @object['quoteUrl'] || @object['quoteURL'] || @object['_misskey_quote']
   end
 
   def join_group!

--- a/app/lib/status_reach_finder.rb
+++ b/app/lib/status_reach_finder.rb
@@ -54,6 +54,7 @@ class StatusReachFinder
       reblogs_account_ids,
       favourites_account_ids,
       replies_account_ids,
+      quoted_account_id,
     ].tap do |arr|
       arr.flatten!
       arr.compact!
@@ -86,6 +87,10 @@ class StatusReachFinder
   # Beware: Replies can be created without the author having had access to the status
   def replies_account_ids
     @status.replies.pluck(:account_id) if distributable? || unsafe?
+  end
+
+  def quoted_account_id
+    @status.quote.account_id if @status.quote?
   end
 
   def followers_inboxes

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -330,6 +330,13 @@ class Account < ApplicationRecord
     true
   end
 
+  def allow_quote?
+    return user.setting_allow_quote if local? && user.present?
+    return settings['allow_quote'] if settings.present? && settings.key?('allow_quote')
+
+    true
+  end
+
   def public_statuses_count
     hide_statuses_count? ? 0 : statuses_count
   end
@@ -407,6 +414,7 @@ class Account < ApplicationRecord
       'hide_followers_count' => hide_followers_count?,
       'translatable_private' => translatable_private?,
       'link_preview' => link_preview?,
+      'allow_quote' => allow_quote?,
     }
     if Setting.enable_emoji_reaction
       config = config.merge({

--- a/app/models/concerns/has_user_settings.rb
+++ b/app/models/concerns/has_user_settings.rb
@@ -111,6 +111,18 @@ module HasUserSettings
     settings['web.use_system_font']
   end
 
+  def setting_show_quote_in_home
+    settings['web.show_quote_in_home']
+  end
+
+  def setting_show_quote_in_public
+    settings['web.show_quote_in_public']
+  end
+
+  def setting_allow_quote
+    settings['allow_quote']
+  end
+
   def setting_noindex
     settings['noindex']
   end

--- a/app/models/concerns/has_user_settings.rb
+++ b/app/models/concerns/has_user_settings.rb
@@ -139,10 +139,6 @@ module HasUserSettings
     settings['link_preview']
   end
 
-  def setting_single_ref_to_quote
-    settings['single_ref_to_quote']
-  end
-
   def setting_dtl_force_with_tag
     settings['dtl_force_with_tag']&.to_sym || :none
   end

--- a/app/models/concerns/has_user_settings.rb
+++ b/app/models/concerns/has_user_settings.rb
@@ -119,6 +119,10 @@ module HasUserSettings
     settings['web.show_quote_in_public']
   end
 
+  def setting_hide_blocking_quote
+    settings['web.hide_blocking_quote']
+  end
+
   def setting_allow_quote
     settings['allow_quote']
   end

--- a/app/models/custom_filter.rb
+++ b/app/models/custom_filter.rb
@@ -104,10 +104,11 @@ class CustomFilter < ApplicationRecord
       if rules[:keywords].present?
         match = rules[:keywords].match(status.proper.searchable_text)
         match = rules[:keywords].match(status.proper.references.pluck(:text).join("\n\n")) if match.nil? && status.proper.references.exists?
+        match = rules[:keywords].match(status.proper.references.pluck(:spoiler_text).join("\n\n")) if match.nil? && status.proper.references.exists?
       end
       keyword_matches = [match.to_s] unless match.nil?
 
-      status_matches = [status.id, status.reblog_of_id].compact & rules[:status_ids] if rules[:status_ids].present?
+      status_matches = [status.id, status.reblog_of_id, status.quote_id].compact & rules[:status_ids] if rules[:status_ids].present?
 
       next if keyword_matches.blank? && status_matches.blank?
 

--- a/app/models/custom_filter.rb
+++ b/app/models/custom_filter.rb
@@ -14,6 +14,7 @@
 #  action             :integer          default("warn"), not null
 #  exclude_follows    :boolean          default(FALSE), not null
 #  exclude_localusers :boolean          default(FALSE), not null
+#  with_quote         :boolean          default(TRUE), not null
 #
 
 class CustomFilter < ApplicationRecord
@@ -33,7 +34,7 @@ class CustomFilter < ApplicationRecord
   include Expireable
   include Redisable
 
-  enum action: { warn: 0, hide: 1 }, _suffix: :action
+  enum action: { warn: 0, hide: 1, half_warn: 2 }, _suffix: :action
 
   belongs_to :account
   has_many :keywords, class_name: 'CustomFilterKeyword', inverse_of: :custom_filter, dependent: :destroy
@@ -103,12 +104,15 @@ class CustomFilter < ApplicationRecord
 
       if rules[:keywords].present?
         match = rules[:keywords].match(status.proper.searchable_text)
-        match = rules[:keywords].match(status.proper.references.pluck(:text).join("\n\n")) if match.nil? && status.proper.references.exists?
-        match = rules[:keywords].match(status.proper.references.pluck(:spoiler_text).join("\n\n")) if match.nil? && status.proper.references.exists?
+        if match.nil? && filter.with_quote && status.proper.references.exists?
+          match = rules[:keywords].match(status.proper.references.pluck(:text).join("\n\n"))
+          match = rules[:keywords].match(status.proper.references.pluck(:spoiler_text).join("\n\n")) if match.nil?
+        end
       end
       keyword_matches = [match.to_s] unless match.nil?
 
-      status_matches = [status.id, status.reblog_of_id, status.quote_id].compact & rules[:status_ids] if rules[:status_ids].present?
+      reference_ids = filter.with_quote ? status.proper.references.pluck(:id) : []
+      status_matches = ([status.id, status.reblog_of_id] + reference_ids).compact & rules[:status_ids] if rules[:status_ids].present?
 
       next if keyword_matches.blank? && status_matches.blank?
 

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -243,6 +243,10 @@ class Status < ApplicationRecord
     !reblog_of_id.nil?
   end
 
+  def quote?
+    !quote_of_id.nil?
+  end
+
   delegate :id, to: :quote, prefix: true
 
   def within_realtime_window?

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -228,7 +228,7 @@ class Status < ApplicationRecord
   end
 
   def quote
-    reference_objects.where(attribute_type: 'QT').first&.target_status
+    @quote ||= reference_objects.where(quote: true).first&.target_status
   end
 
   def within_realtime_window?
@@ -480,12 +480,12 @@ class Status < ApplicationRecord
       ConversationMute.select('conversation_id').where(conversation_id: conversation_ids).where(account_id: account_id).each_with_object({}) { |m, h| h[m.conversation_id] = true }
     end
 
-    def pins_map(status_ids, account_id)
-      StatusPin.select('status_id').where(status_id: status_ids).where(account_id: account_id).each_with_object({}) { |p, h| h[p.status_id] = true }
+    def blocks_map(account_ids, account_id)
+      Block.where(account_id: account_id, target_account_id: account_ids).each_with_object({}) { |b, h| h[b.target_account_id] = true }
     end
 
-    def emoji_reactions_map(status_ids, account_id)
-      EmojiReaction.select('status_id').where(status_id: status_ids).where(account_id: account_id).each_with_object({}) { |e, h| h[e.status_id] = true }
+    def pins_map(status_ids, account_id)
+      StatusPin.select('status_id').where(status_id: status_ids).where(account_id: account_id).each_with_object({}) { |p, h| h[p.status_id] = true }
     end
 
     def emoji_reaction_allows_map(status_ids, account_id)

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -247,8 +247,6 @@ class Status < ApplicationRecord
     !quote_of_id.nil?
   end
 
-  delegate :id, to: :quote, prefix: true
-
   def within_realtime_window?
     created_at >= REAL_TIME_WINDOW.ago
   end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -231,6 +231,10 @@ class Status < ApplicationRecord
     @quote ||= reference_objects.where(quote: true).first&.target_status
   end
 
+  def quote_id
+    reference_objects.where(quote: true).first&.target_status_id
+  end
+
   def within_realtime_window?
     created_at >= REAL_TIME_WINDOW.ago
   end

--- a/app/models/status_reference.rb
+++ b/app/models/status_reference.rb
@@ -20,11 +20,27 @@ class StatusReference < ApplicationRecord
   has_one :notification, as: :activity, dependent: :destroy
 
   after_commit :reset_parent_cache
+  after_create_commit :set_quote
+  after_destroy_commit :remove_quote
 
   private
 
   def reset_parent_cache
     Rails.cache.delete("statuses/#{status_id}")
     Rails.cache.delete("statuses/#{target_status_id}")
+  end
+
+  def set_quote
+    return unless quote
+    return if status.quote_of_id.present?
+
+    status.quote_of_id = target_status_id
+  end
+
+  def remove_quote
+    return unless quote
+    return unless status.quote_of_id == target_status_id
+
+    status.quote_of_id = nil
   end
 end

--- a/app/models/status_reference.rb
+++ b/app/models/status_reference.rb
@@ -10,6 +10,7 @@
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
 #  attribute_type   :string
+#  quote            :boolean          default(FALSE), not null
 #
 
 class StatusReference < ApplicationRecord

--- a/app/models/user_settings.rb
+++ b/app/models/user_settings.rb
@@ -69,6 +69,7 @@ class UserSettings
     setting :simple_timeline_menu, default: false
     setting :show_quote_in_home, default: true
     setting :show_quote_in_public, default: false
+    setting :hide_blocking_quote, default: true
   end
 
   namespace :notification_emails do

--- a/app/models/user_settings.rb
+++ b/app/models/user_settings.rb
@@ -42,6 +42,7 @@ class UserSettings
   setting :dtl_force_subscribable, default: false
   setting :lock_follow_from_bot, default: false
   setting :single_ref_to_quote, default: false
+  setting :allow_quote, default: true
 
   setting_inverse_alias :indexable, :noindex
 
@@ -67,6 +68,8 @@ class UserSettings
     setting :display_media_expand, default: true
     setting :auto_play, default: true
     setting :simple_timeline_menu, default: false
+    setting :show_quote_in_home, default: true
+    setting :show_quote_in_public, default: false
   end
 
   namespace :notification_emails do

--- a/app/models/user_settings.rb
+++ b/app/models/user_settings.rb
@@ -41,7 +41,6 @@ class UserSettings
   setting :dtl_force_with_tag, default: :none, in: %w(full searchability none)
   setting :dtl_force_subscribable, default: false
   setting :lock_follow_from_bot, default: false
-  setting :single_ref_to_quote, default: false
   setting :allow_quote, default: true
 
   setting_inverse_alias :indexable, :noindex

--- a/app/policies/status_policy.rb
+++ b/app/policies/status_policy.rb
@@ -40,6 +40,10 @@ class StatusPolicy < ApplicationPolicy
     show? && !blocking_author?
   end
 
+  def quote?
+    %i(public public_unlisted unlisted).include?(record.visibility.to_sym) && show? && !blocking_author?
+  end
+
   def destroy?
     owned?
   end

--- a/app/presenters/status_relationships_presenter.rb
+++ b/app/presenters/status_relationships_presenter.rb
@@ -14,6 +14,7 @@ class StatusRelationshipsPresenter
       @favourites_map      = {}
       @bookmarks_map       = {}
       @mutes_map           = {}
+      @blocks_map          = {}
       @pins_map            = {}
       @filters_map         = {}
       @emoji_reaction_allows_map = nil
@@ -28,7 +29,7 @@ class StatusRelationshipsPresenter
       @favourites_map  = Status.favourites_map(status_ids, current_account_id).merge(options[:favourites_map] || {})
       @bookmarks_map   = Status.bookmarks_map(status_ids, current_account_id).merge(options[:bookmarks_map] || {})
       @mutes_map       = Status.mutes_map(conversation_ids, current_account_id).merge(options[:mutes_map] || {})
-      @blocks_map      = Status.blocks_map(conversation_ids, current_account_id).merge(options[:blocks_map] || {})
+      @blocks_map      = Status.blocks_map(statuses.map(&:account_id), current_account_id).merge(options[:blocks_map] || {})
       @pins_map        = Status.pins_map(pinnable_status_ids, current_account_id).merge(options[:pins_map] || {})
       @emoji_reaction_allows_map = Status.emoji_reaction_allows_map(status_ids, current_account_id).merge(options[:emoji_reaction_allows_map] || {})
       @attributes_map  = options[:attributes_map] || {}

--- a/app/presenters/status_relationships_presenter.rb
+++ b/app/presenters/status_relationships_presenter.rb
@@ -20,7 +20,8 @@ class StatusRelationshipsPresenter
       @filters_map         = {}
       @emoji_reaction_allows_map = nil
     else
-      statuses            = statuses.compact
+      statuses = statuses.compact
+      statuses += statuses.filter_map(&:quote)
       status_ids          = statuses.flat_map { |s| [s.id, s.reblog_of_id] }.uniq.compact
       conversation_ids    = statuses.filter_map(&:conversation_id).uniq
       pinnable_status_ids = statuses.map(&:proper).filter_map { |s| s.id if s.account_id == current_account_id && PINNABLE_VISIBILITIES.include?(s.visibility) }

--- a/app/presenters/status_relationships_presenter.rb
+++ b/app/presenters/status_relationships_presenter.rb
@@ -3,7 +3,7 @@
 class StatusRelationshipsPresenter
   PINNABLE_VISIBILITIES = %w(public public_unlisted unlisted login private).freeze
 
-  attr_reader :reblogs_map, :favourites_map, :mutes_map, :pins_map, :blocks_map,
+  attr_reader :reblogs_map, :favourites_map, :mutes_map, :pins_map, :blocks_map, :domain_blocks_map,
               :bookmarks_map, :filters_map, :attributes_map, :emoji_reaction_allows_map
 
   def initialize(statuses, current_account_id = nil, **options)
@@ -15,6 +15,7 @@ class StatusRelationshipsPresenter
       @bookmarks_map       = {}
       @mutes_map           = {}
       @blocks_map          = {}
+      @domain_blocks_map   = {}
       @pins_map            = {}
       @filters_map         = {}
       @emoji_reaction_allows_map = nil
@@ -24,15 +25,16 @@ class StatusRelationshipsPresenter
       conversation_ids    = statuses.filter_map(&:conversation_id).uniq
       pinnable_status_ids = statuses.map(&:proper).filter_map { |s| s.id if s.account_id == current_account_id && PINNABLE_VISIBILITIES.include?(s.visibility) }
 
-      @filters_map     = build_filters_map(statuses, current_account_id).merge(options[:filters_map] || {})
-      @reblogs_map     = Status.reblogs_map(status_ids, current_account_id).merge(options[:reblogs_map] || {})
-      @favourites_map  = Status.favourites_map(status_ids, current_account_id).merge(options[:favourites_map] || {})
-      @bookmarks_map   = Status.bookmarks_map(status_ids, current_account_id).merge(options[:bookmarks_map] || {})
-      @mutes_map       = Status.mutes_map(conversation_ids, current_account_id).merge(options[:mutes_map] || {})
-      @blocks_map      = Status.blocks_map(statuses.map(&:account_id), current_account_id).merge(options[:blocks_map] || {})
-      @pins_map        = Status.pins_map(pinnable_status_ids, current_account_id).merge(options[:pins_map] || {})
+      @filters_map       = build_filters_map(statuses, current_account_id).merge(options[:filters_map] || {})
+      @reblogs_map       = Status.reblogs_map(status_ids, current_account_id).merge(options[:reblogs_map] || {})
+      @favourites_map    = Status.favourites_map(status_ids, current_account_id).merge(options[:favourites_map] || {})
+      @bookmarks_map     = Status.bookmarks_map(status_ids, current_account_id).merge(options[:bookmarks_map] || {})
+      @mutes_map         = Status.mutes_map(conversation_ids, current_account_id).merge(options[:mutes_map] || {})
+      @blocks_map        = Status.blocks_map(statuses.map(&:account_id), current_account_id).merge(options[:blocks_map] || {})
+      @domain_blocks_map = Status.domain_blocks_map(statuses.filter_map { |status| status.account.domain }.uniq, current_account_id).merge(options[:domain_blocks_map] || {})
+      @pins_map          = Status.pins_map(pinnable_status_ids, current_account_id).merge(options[:pins_map] || {})
       @emoji_reaction_allows_map = Status.emoji_reaction_allows_map(status_ids, current_account_id).merge(options[:emoji_reaction_allows_map] || {})
-      @attributes_map  = options[:attributes_map] || {}
+      @attributes_map = options[:attributes_map] || {}
     end
   end
 

--- a/app/presenters/status_relationships_presenter.rb
+++ b/app/presenters/status_relationships_presenter.rb
@@ -3,8 +3,8 @@
 class StatusRelationshipsPresenter
   PINNABLE_VISIBILITIES = %w(public public_unlisted unlisted login private).freeze
 
-  attr_reader :reblogs_map, :favourites_map, :mutes_map, :pins_map,
-              :bookmarks_map, :filters_map, :emoji_reactions_map, :attributes_map, :emoji_reaction_allows_map
+  attr_reader :reblogs_map, :favourites_map, :mutes_map, :pins_map, :blocks_map,
+              :bookmarks_map, :filters_map, :attributes_map, :emoji_reaction_allows_map
 
   def initialize(statuses, current_account_id = nil, **options)
     @current_account_id = current_account_id
@@ -16,7 +16,6 @@ class StatusRelationshipsPresenter
       @mutes_map           = {}
       @pins_map            = {}
       @filters_map         = {}
-      @emoji_reactions_map = {}
       @emoji_reaction_allows_map = nil
     else
       statuses            = statuses.compact
@@ -29,8 +28,8 @@ class StatusRelationshipsPresenter
       @favourites_map  = Status.favourites_map(status_ids, current_account_id).merge(options[:favourites_map] || {})
       @bookmarks_map   = Status.bookmarks_map(status_ids, current_account_id).merge(options[:bookmarks_map] || {})
       @mutes_map       = Status.mutes_map(conversation_ids, current_account_id).merge(options[:mutes_map] || {})
+      @blocks_map      = Status.blocks_map(conversation_ids, current_account_id).merge(options[:blocks_map] || {})
       @pins_map        = Status.pins_map(pinnable_status_ids, current_account_id).merge(options[:pins_map] || {})
-      @emoji_reactions_map = Status.emoji_reactions_map(status_ids, current_account_id).merge(options[:emoji_reactions_map] || {})
       @emoji_reaction_allows_map = Status.emoji_reaction_allows_map(status_ids, current_account_id).merge(options[:emoji_reaction_allows_map] || {})
       @attributes_map  = options[:attributes_map] || {}
     end

--- a/app/serializers/activitypub/note_serializer.rb
+++ b/app/serializers/activitypub/note_serializer.rb
@@ -170,12 +170,10 @@ class ActivityPub::NoteSerializer < ActivityPub::Serializer
     object.account.local?
   end
 
-  def quote?
-    @quote ||= (object.reference_objects.count == 1 && object.account.user&.settings&.[]('single_ref_to_quote')) || object.reference_objects.where(attribute_type: 'QT').count == 1
-  end
+  delegate :quote?, to: :object
 
   def quote_post
-    @quote_post ||= object.quote || object.references.first
+    @quote_post ||= object.quote
   end
 
   def quote_uri

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -62,6 +62,8 @@ class InitialStateSerializer < ActiveModel::Serializer
       store[:show_trends]       = Setting.trends && object.current_account.user.setting_trends
       store[:bookmark_category_needed] = object.current_account.user.setting_bookmark_category_needed
       store[:simple_timeline_menu] = object.current_account.user.setting_simple_timeline_menu
+      store[:show_quote_in_home] = object.current_account.user.setting_show_quote_in_home
+      store[:show_quote_in_public] = object.current_account.user.setting_show_quote_in_public
     else
       store[:auto_play_gif] = Setting.auto_play_gif
       store[:display_media] = Setting.display_media
@@ -69,6 +71,8 @@ class InitialStateSerializer < ActiveModel::Serializer
       store[:use_blurhash]  = Setting.use_blurhash
       store[:enable_emoji_reaction] = Setting.enable_emoji_reaction
       store[:show_emoji_reaction_on_timeline] = Setting.enable_emoji_reaction
+      store[:show_quote_in_home] = true
+      store[:show_quote_in_public] = true
     end
 
     store[:disabled_account_id] = object.disabled_account.id.to_s if object.disabled_account

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -64,6 +64,7 @@ class InitialStateSerializer < ActiveModel::Serializer
       store[:simple_timeline_menu] = object.current_account.user.setting_simple_timeline_menu
       store[:show_quote_in_home] = object.current_account.user.setting_show_quote_in_home
       store[:show_quote_in_public] = object.current_account.user.setting_show_quote_in_public
+      store[:hide_blocking_quote] = object.current_account.user.setting_hide_blocking_quote
     else
       store[:auto_play_gif] = Setting.auto_play_gif
       store[:display_media] = Setting.display_media

--- a/app/serializers/rest/status_serializer.rb
+++ b/app/serializers/rest/status_serializer.rb
@@ -5,7 +5,7 @@ class REST::StatusSerializer < ActiveModel::Serializer
 
   attributes :id, :created_at, :in_reply_to_id, :in_reply_to_account_id,
              :sensitive, :spoiler_text, :visibility, :visibility_ex, :limited_scope, :language,
-             :uri, :url, :replies_count, :reblogs_count, :searchability, :markdown, :quote_id,
+             :uri, :url, :replies_count, :reblogs_count, :searchability, :markdown,
              :status_reference_ids, :status_references_count, :status_referred_by_count,
              :favourites_count, :emoji_reactions, :emoji_reactions_count, :reactions, :edited_at
 
@@ -16,6 +16,7 @@ class REST::StatusSerializer < ActiveModel::Serializer
   attribute :pinned, if: :pinnable?
   attribute :reactions, if: :reactions?
   attribute :expires_at, if: :will_expire?
+  attribute :quote_id, if: :quote?
   has_many :filtered, serializer: REST::FilterResultSerializer, if: :current_user?
 
   attribute :content, unless: :source_requested?
@@ -48,7 +49,7 @@ class REST::StatusSerializer < ActiveModel::Serializer
       end
     end
   end
-  belongs_to :quote, serializer: QuotedStatusSerializer
+  belongs_to :quote, if: :quote?, serializer: QuotedStatusSerializer
 
   def id
     object.id.to_s
@@ -179,6 +180,8 @@ class REST::StatusSerializer < ActiveModel::Serializer
   def quote_id
     object.quote_of_id
   end
+
+  delegate :quote?, to: :object
 
   def reblogged
     if relationships

--- a/app/serializers/rest/status_serializer.rb
+++ b/app/serializers/rest/status_serializer.rb
@@ -178,7 +178,7 @@ class REST::StatusSerializer < ActiveModel::Serializer
   end
 
   def quote_id
-    object.quote_of_id
+    object.quote_of_id.to_s
   end
 
   delegate :quote?, to: :object

--- a/app/serializers/rest/status_serializer.rb
+++ b/app/serializers/rest/status_serializer.rb
@@ -34,17 +34,17 @@ class REST::StatusSerializer < ActiveModel::Serializer
   has_one :preloadable_poll, key: :poll, serializer: REST::PollSerializer
 
   class QuotedStatusSerializer < REST::StatusSerializer
-    attribute :blocked, if: :current_user?
+    attribute :quote_muted, if: :current_user?
 
     def quote
       nil
     end
 
-    def blocked
+    def quote_muted
       if relationships
-        relationships.blocks_map[object.account_id] || false
+        muted || relationships.blocks_map[object.account_id] || relationships.domain_blocks_map[object.account.domain] || false
       else
-        current_user.account.blocking?(object.account_id)
+        muted || current_user.account.blocking?(object.account_id) || current_user.account.domain_blocking?(object.account.domain)
       end
     end
   end

--- a/app/serializers/rest/status_serializer.rb
+++ b/app/serializers/rest/status_serializer.rb
@@ -177,7 +177,7 @@ class REST::StatusSerializer < ActiveModel::Serializer
   end
 
   def quote_id
-    object.quote&.id
+    object.quote_of_id
   end
 
   def reblogged

--- a/app/serializers/rest/status_serializer.rb
+++ b/app/serializers/rest/status_serializer.rb
@@ -49,7 +49,7 @@ class REST::StatusSerializer < ActiveModel::Serializer
       end
     end
   end
-  belongs_to :quote, if: :quote?, serializer: QuotedStatusSerializer
+  belongs_to :quote, if: :quote?, serializer: QuotedStatusSerializer, relationships: -> { relationships }
 
   def id
     object.id.to_s

--- a/app/services/activitypub/process_status_update_service.rb
+++ b/app/services/activitypub/process_status_update_service.rb
@@ -254,9 +254,8 @@ class ActivityPub::ProcessStatusUpdateService < BaseService
   def update_references!
     references = @json['references'].nil? ? [] : ActivityPub::FetchReferencesService.new.call(@status, @json['references'])
     quote = @json['quote'] || @json['quoteUrl'] || @json['quoteURL'] || @json['_misskey_quote']
-    references << quote if quote
 
-    ProcessReferencesService.perform_worker_async(@status, [], references)
+    ProcessReferencesService.perform_worker_async(@status, [], references, [quote].compact)
   end
 
   def expected_type?

--- a/app/services/process_references_service.rb
+++ b/app/services/process_references_service.rb
@@ -118,7 +118,10 @@ class ProcessReferencesService < BaseService
     statuses.each do |status|
       attribute_type = quote_status_ids.include?(status.id) ? 'QT' : @attributes[status.id]
       attribute_type = 'BT' unless quotable?(status)
-      @added_objects << @status.reference_objects.new(target_status: status, attribute_type: attribute_type, quote: attribute_type.casecmp('QT').zero?)
+      quote_type = attribute_type.casecmp('QT').zero?
+      @status.quote_of_id = status.id if quote_type && @status.quote_of_id.nil?
+      @added_objects << @status.reference_objects.new(target_status: status, attribute_type: attribute_type, quote: quote_type)
+
       status.increment_count!(:status_referred_by_count)
       @references_count += 1
 

--- a/app/services/process_references_service.rb
+++ b/app/services/process_references_service.rb
@@ -106,7 +106,7 @@ class ProcessReferencesService < BaseService
   end
 
   def quotable?(target_status)
-    StatusPolicy.new(@status.account, target_status).quote?
+    @status.account.allow_quote && StatusPolicy.new(@status.account, target_status).quote?
   end
 
   def add_references

--- a/app/services/process_references_service.rb
+++ b/app/services/process_references_service.rb
@@ -31,7 +31,7 @@ class ProcessReferencesService < BaseService
 
           @status.save!
         end
-        quote_ur
+
         create_notifications!
       end
 
@@ -45,14 +45,14 @@ class ProcessReferencesService < BaseService
     reference_parameters.any? || (urls || []).any? || FormattingHelper.extract_status_plain_text(status).scan(REFURL_EXP).pluck(3).uniq.any?
   end
 
-  def self.perform_worker_async(status, reference_parameters, urls, quote_urls)
+  def self.perform_worker_async(status, reference_parameters, urls, quote_urls = [])
     return unless need_process?(status, reference_parameters, urls)
 
     Rails.cache.write("status_reference:#{status.id}", true, expires_in: 10.minutes)
     ProcessReferencesWorker.perform_async(status.id, reference_parameters, urls, [], quote_urls || [])
   end
 
-  def self.call_service(status, reference_parameters, urls, quote_urls)
+  def self.call_service(status, reference_parameters, urls, quote_urls = [])
     return unless need_process?(status, reference_parameters, urls)
 
     ProcessReferencesService.new.call(status, reference_parameters || [], urls: urls || [], fetch_remote: false, quote_urls: quote_urls)

--- a/app/services/process_references_service.rb
+++ b/app/services/process_references_service.rb
@@ -106,7 +106,7 @@ class ProcessReferencesService < BaseService
   end
 
   def quotable?(target_status)
-    @status.account.allow_quote && StatusPolicy.new(@status.account, target_status).quote?
+    @status.account.allow_quote? && StatusPolicy.new(@status.account, target_status).quote?
   end
 
   def add_references

--- a/app/services/process_references_service.rb
+++ b/app/services/process_references_service.rb
@@ -119,6 +119,7 @@ class ProcessReferencesService < BaseService
       attribute_type = quote_status_ids.include?(status.id) ? 'QT' : @attributes[status.id]
       attribute_type = 'BT' unless quotable?(status)
       quote_type = attribute_type.present? ? attribute_type.casecmp('QT').zero? : false
+      @status.quote_of_id = status.id if quote_type && (@status.quote_of_id.nil? || references.exclude?(@status.quote_of_id))
       @added_objects << @status.reference_objects.new(target_status: status, attribute_type: attribute_type, quote: quote_type)
 
       status.increment_count!(:status_referred_by_count)

--- a/app/services/resolve_url_service.rb
+++ b/app/services/resolve_url_service.rb
@@ -6,16 +6,16 @@ class ResolveURLService < BaseService
 
   USERNAME_STATUS_RE = %r{/@(?<username>#{Account::USERNAME_RE})/(?<status_id>[0-9]+)\Z}
 
-  def call(url, on_behalf_of: nil, fetch_remote: true)
+  def call(url, on_behalf_of: nil, fetch_remote: true, local_only: false)
     @url          = url
     @on_behalf_of = on_behalf_of
     @fetch_remote = fetch_remote
 
     if local_url?
       process_local_url
-    elsif fetch_remote && !fetched_resource.nil?
+    elsif !local_only && fetch_remote && !fetched_resource.nil?
       process_url
-    else
+    elsif !local_only
       process_url_from_db
     end
   end

--- a/app/views/filters/_filter_fields.html.haml
+++ b/app/views/filters/_filter_fields.html.haml
@@ -10,11 +10,14 @@
 %hr.spacer/
 
 .fields-group
-  = f.input :filter_action, as: :radio_buttons, collection: %i(warn hide), include_blank: false, wrapper: :with_block_label, label_method: ->(action) { safe_join([t("simple_form.labels.filters.actions.#{action}"), content_tag(:span, t("simple_form.hints.filters.actions.#{action}"), class: 'hint')]) }, hint: t('simple_form.hints.filters.action'), required: true
+  = f.input :filter_action, as: :radio_buttons, collection: %i(half_warn warn hide), include_blank: false, wrapper: :with_block_label, label_method: ->(action) { safe_join([t("simple_form.labels.filters.actions.#{action}"), content_tag(:span, t("simple_form.hints.filters.actions.#{action}"), class: 'hint')]) }, hint: t('simple_form.hints.filters.action'), required: true
 
 .fields-group
   = f.input :exclude_follows, wrapper: :with_label, kmyblue: true, label: t('simple_form.labels.filters.options.exclude_follows')
   = f.input :exclude_localusers, wrapper: :with_label, kmyblue: true, label: t('simple_form.labels.filters.options.exclude_localusers')
+
+.fields-group
+  = f.input :with_quote, wrapper: :with_label, kmyblue: true, label: t('simple_form.labels.filters.options.with_quote')
 
 %hr.spacer/
 

--- a/app/views/settings/preferences/appearance/show.html.haml
+++ b/app/views/settings/preferences/appearance/show.html.haml
@@ -49,6 +49,7 @@
     .fields-group
       = ff.input :'web.show_quote_in_home', wrapper: :with_label, kmyblue: true, label: I18n.t('simple_form.labels.defaults.setting_show_quote_in_home'), hint: false
       = ff.input :'web.show_quote_in_public', wrapper: :with_label, kmyblue: true, label: I18n.t('simple_form.labels.defaults.setting_show_quote_in_public'), hint: false
+      = ff.input :'web.hide_blocking_quote', wrapper: :with_label, kmyblue: true, label: I18n.t('simple_form.labels.defaults.setting_hide_blocking_quote'), hint: false
 
     .fields-group
       = ff.input :'web.simple_timeline_menu', wrapper: :with_label, kmyblue: true, label: I18n.t('simple_form.labels.defaults.setting_simple_timeline_menu')

--- a/app/views/settings/preferences/appearance/show.html.haml
+++ b/app/views/settings/preferences/appearance/show.html.haml
@@ -47,6 +47,10 @@
       = ff.input :'web.bookmark_category_needed', wrapper: :with_label, kmyblue: true, label: I18n.t('simple_form.labels.defaults.setting_bookmark_category_needed'), hint: I18n.t('simple_form.hints.defaults.setting_bookmark_category_needed')
 
     .fields-group
+      = ff.input :'web.show_quote_in_home', wrapper: :with_label, kmyblue: true, label: I18n.t('simple_form.labels.defaults.setting_show_quote_in_home'), hint: false
+      = ff.input :'web.show_quote_in_public', wrapper: :with_label, kmyblue: true, label: I18n.t('simple_form.labels.defaults.setting_show_quote_in_public'), hint: false
+
+    .fields-group
       = ff.input :'web.simple_timeline_menu', wrapper: :with_label, kmyblue: true, label: I18n.t('simple_form.labels.defaults.setting_simple_timeline_menu')
 
     %h4= t 'appearance.discovery'

--- a/app/views/settings/preferences/other/show.html.haml
+++ b/app/views/settings/preferences/other/show.html.haml
@@ -14,9 +14,6 @@
     .fields-group
       = ff.input :lock_follow_from_bot, wrapper: :with_label, kmyblue: true, label: I18n.t('simple_form.labels.defaults.setting_lock_follow_from_bot')
 
-    .fields-group
-      = ff.input :single_ref_to_quote, wrapper: :with_label, kmyblue: true, label: I18n.t('simple_form.labels.defaults.setting_single_ref_to_quote'), hint: I18n.t('simple_form.hints.defaults.setting_single_ref_to_quote')
-
     %h4= t 'preferences.posting_defaults'
 
     .fields-row

--- a/app/views/settings/privacy_extra/show.html.haml
+++ b/app/views/settings/privacy_extra/show.html.haml
@@ -21,6 +21,9 @@
     .fields-group
       = ff.input :link_preview, wrapper: :with_label, kmyblue: true, label: I18n.t('simple_form.labels.defaults.setting_link_preview'), hint: I18n.t('simple_form.hints.defaults.setting_link_preview')
 
+    .fields-group
+      = ff.input :allow_quote, wrapper: :with_label, kmyblue: true, label: I18n.t('simple_form.labels.defaults.setting_allow_quote'), hint: false
+
   %h4= t 'privacy_extra.stop_deliver'
 
   %p.lead= t('privacy_extra.stop_deliver_hint_html')

--- a/app/workers/process_references_worker.rb
+++ b/app/workers/process_references_worker.rb
@@ -5,8 +5,8 @@ class ProcessReferencesWorker
 
   sidekiq_options queue: 'pull', retry: 3
 
-  def perform(status_id, ids, urls, no_fetch_urls = nil)
-    ProcessReferencesService.new.call(Status.find(status_id), ids || [], urls: urls || [], no_fetch_urls: no_fetch_urls)
+  def perform(status_id, ids, urls, no_fetch_urls = nil, quote_urls = nil)
+    ProcessReferencesService.new.call(Status.find(status_id), ids || [], urls: urls || [], no_fetch_urls: no_fetch_urls, quote_urls: quote_urls || [])
   rescue ActiveRecord::RecordNotFound
     true
   end

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -227,6 +227,7 @@ en:
         phrase: Keyword or phrase
         setting_advanced_layout: Enable advanced web interface
         setting_aggregate_reblogs: Group boosts in timelines
+        setting_allow_quote: Allow quote your posts
         setting_always_send_emails: Always send e-mail notifications
         setting_auto_play_gif: Auto-play animated GIFs
         setting_bio_markdown: Enable profile markdown
@@ -275,6 +276,8 @@ en:
         setting_send_without_domain_blocks: Send your post to all server with administrator set as rejecting-post-server for protect you [DEPRECATED]
         setting_show_application: Disclose application used to send posts
         setting_show_emoji_reaction_on_timeline: Show all stamps on timeline
+        setting_show_quote_in_home: Show quotes in home, list or antenna timelines
+        setting_show_quote_in_public: Show quotes in public timelines
         setting_simple_timeline_menu: Reduce post menu on timeline
         setting_single_ref_to_quote: Deliver single reference to other server as quote
         setting_stay_privacy: Not change privacy after post

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -261,6 +261,7 @@ en:
           mutuals_only: Mutuals only
           outside_only: Followings or followers only
         setting_expand_spoilers: Always expand posts marked with content warnings
+        setting_hide_blocking_quote: Hide posts which have a quote written by the user you are blocking
         setting_hide_followers_count: Hide followers count
         setting_hide_following_count: Hide following count
         setting_hide_network: Hide your social graph

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -87,6 +87,7 @@ en:
       filters:
         action: Chose which action to perform when a post matches the filter
         actions:
+          half_warn: Hide the filtered content (exclude account info) behind a warning mentioning the filter's title
           hide: Completely hide the filtered content, behaving as if it did not exist
           warn: Hide the filtered content behind a warning mentioning the filter's title
       form_admin_settings:
@@ -308,11 +309,13 @@ en:
         name: Hashtag
       filters:
         actions:
+          half_warn: Half hide with a warning
           hide: Hide completely
           warn: Hide with a warning
         options:
           exclude_follows: Exclude following users
           exclude_localusers: Exclude local users
+          with_quote: Also check quote or references
       form_admin_settings:
         activity_api_enabled: Publish aggregate statistics about user activity in the API
         backups_retention_period: User archive retention period

--- a/config/locales/simple_form.ja.yml
+++ b/config/locales/simple_form.ja.yml
@@ -100,6 +100,7 @@ ja:
       filters:
         action: 投稿がフィルタに一致したときに実行するアクションを選択
         actions:
+          half_warn: フィルターに一致した投稿の本文のみを非表示にし、フィルターのタイトルを含む警告を表示します
           hide: フィルタに一致した投稿を完全に非表示にします
           warn: フィルタに一致した投稿を非表示にし、フィルタのタイトルを含む警告を表示します
       form_admin_settings:
@@ -323,11 +324,13 @@ ja:
         name: ハッシュタグ
       filters:
         actions:
+          half_warn: アカウント名だけを出し、本文は警告で隠す
           hide: 完全に隠す
           warn: 警告付きで隠す
         options:
           exclude_follows: フォロー中のユーザーをフィルターの対象にしない
           exclude_localusers: ローカルユーザーをフィルターの対象にしない
+          with_quote: 引用・参照の内容をフィルターの対象に含める
       form_admin_settings:
         activity_api_enabled: APIでユーザーアクティビティに関する集計統計を公開する
         backups_retention_period: ユーザーアーカイブの保持期間

--- a/config/locales/simple_form.ja.yml
+++ b/config/locales/simple_form.ja.yml
@@ -240,6 +240,7 @@ ja:
         phrase: キーワードまたはフレーズ
         setting_advanced_layout: 上級者向けUIを有効にする
         setting_aggregate_reblogs: ブーストをまとめる
+        setting_allow_quote: 引用を許可する
         setting_always_send_emails: 常にメール通知を送信する
         setting_auto_play_gif: アニメーションGIFを自動再生する
         setting_bio_markdown: プロフィールのMarkdownを有効にする
@@ -281,6 +282,8 @@ ja:
         setting_hide_statuses_count: 投稿数を隠す
         setting_link_preview: リンクのプレビューを生成する
         setting_lock_follow_from_bot: botからのフォローを承認制にする
+        setting_show_quote_in_home: ホーム・リスト・アンテナなどで引用を表示する
+        setting_show_quote_in_public: 公開タイムライン（ローカル・連合）で引用を表示する
         setting_stay_privacy: 投稿時に公開範囲を保存する
         setting_noai: 自分のコンテンツのAI学習利用に対して不快感を表明する
         setting_public_post_to_unlisted: サードパーティから公開範囲「公開」で投稿した場合、「ローカル公開」に変更する

--- a/config/locales/simple_form.ja.yml
+++ b/config/locales/simple_form.ja.yml
@@ -275,6 +275,7 @@ ja:
         setting_emoji_reaction_streaming_notify_impl2: Nyastodon, Catstodon, glitch-soc互換のスタンプ機能を有効にする
         setting_enable_emoji_reaction: スタンプ機能を使用する
         setting_expand_spoilers: 閲覧注意としてマークされた投稿を常に展開する
+        setting_hide_blocking_quote: ブロックしたユーザーの投稿を引用した投稿を隠す
         setting_hide_followers_count: フォロワー数を隠す
         setting_hide_following_count: フォロー数を隠す
         setting_hide_network: 繋がりを隠す

--- a/db/migrate/20230930233930_add_quote_to_status_references.rb
+++ b/db/migrate/20230930233930_add_quote_to_status_references.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require Rails.root.join('lib', 'mastodon', 'migration_helpers')
+
+class AddQuoteToStatusReferences < ActiveRecord::Migration[7.0]
+  include Mastodon::MigrationHelpers
+
+  disable_ddl_transaction!
+
+  class StatusReference < ApplicationRecord; end
+
+  def up
+    safety_assured do
+      add_column_with_default :status_references, :quote, :boolean, default: false, allow_null: false
+      StatusReference.where(attribute_type: 'QT').update_all(quote: true) # rubocop:disable Rails/SkipsModelValidations
+    end
+  end
+
+  def down
+    safety_assured do
+      remove_column :status_references, :quote
+    end
+  end
+end

--- a/db/migrate/20231001031337_add_quote_to_statuses.rb
+++ b/db/migrate/20231001031337_add_quote_to_statuses.rb
@@ -14,7 +14,7 @@ class AddQuoteToStatuses < ActiveRecord::Migration[7.0]
 
   def up
     safety_assured do
-      add_column_with_default :statuses, :quote_of_id, :bigint, default: nil, allow_null: nil
+      add_column_with_default :statuses, :quote_of_id, :bigint, default: nil, allow_null: true
 
       StatusReference.transaction do
         StatusReference.where(quote: true).includes(:status).each do |ref|

--- a/db/migrate/20231001031337_add_quote_to_statuses.rb
+++ b/db/migrate/20231001031337_add_quote_to_statuses.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require Rails.root.join('lib', 'mastodon', 'migration_helpers')
+
+class AddQuoteToStatuses < ActiveRecord::Migration[7.0]
+  include Mastodon::MigrationHelpers
+
+  disable_ddl_transaction!
+
+  class StatusReference < ApplicationRecord
+    belongs_to :status
+    belongs_to :target_status, class_name: 'Status'
+  end
+
+  def up
+    safety_assured do
+      add_column_with_default :statuses, :quote_of_id, :bigint, default: nil, allow_null: nil
+
+      StatusReference.transaction do
+        StatusReference.where(quote: true).includes(:status).each do |ref|
+          ref.status.update(quote_of_id: ref.target_status_id)
+        end
+      end
+    end
+  end
+
+  def down
+    safety_assured do
+      remove_column :statuses, :quote_of_id
+    end
+  end
+end

--- a/db/migrate/20231001050733_add_with_quote_to_custom_filters.rb
+++ b/db/migrate/20231001050733_add_with_quote_to_custom_filters.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require Rails.root.join('lib', 'mastodon', 'migration_helpers')
+
+class AddWithQuoteToCustomFilters < ActiveRecord::Migration[7.0]
+  include Mastodon::MigrationHelpers
+
+  disable_ddl_transaction!
+
+  def change
+    safety_assured do
+      add_column_with_default :custom_filters, :with_quote, :boolean, default: true, allow_null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_23_103430) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_30_233930) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -1143,6 +1143,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_23_103430) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.string "attribute_type"
+    t.boolean "quote", default: false, null: false
     t.index ["status_id"], name: "index_status_references_on_status_id"
     t.index ["target_status_id"], name: "index_status_references_on_target_status_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_01_031337) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_01_050733) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -536,6 +536,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_01_031337) do
     t.integer "action", default: 0, null: false
     t.boolean "exclude_follows", default: false, null: false
     t.boolean "exclude_localusers", default: false, null: false
+    t.boolean "with_quote", default: true, null: false
     t.index ["account_id"], name: "index_custom_filters_on_account_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_30_233930) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_01_031337) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -1200,6 +1200,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_30_233930) do
     t.integer "searchability"
     t.boolean "markdown", default: false
     t.integer "limited_scope"
+    t.bigint "quote_of_id"
     t.index ["account_id", "id", "visibility", "updated_at"], name: "index_statuses_20190820", order: { id: :desc }, where: "(deleted_at IS NULL)"
     t.index ["account_id"], name: "index_statuses_on_account_id"
     t.index ["deleted_at"], name: "index_statuses_on_deleted_at", where: "(deleted_at IS NOT NULL)"

--- a/spec/fabricators/status_reference_fabricator.rb
+++ b/spec/fabricators/status_reference_fabricator.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+Fabricator(:status_reference) do
+  status         { Fabricate.build(:status) }
+  target_status  { Fabricate.build(:status) }
+  attribute_type 'BT'
+  quote          false
+end

--- a/spec/lib/status_reach_finder_spec.rb
+++ b/spec/lib/status_reach_finder_spec.rb
@@ -8,10 +8,11 @@ describe StatusReachFinder do
       subject { described_class.new(status) }
 
       let(:parent_status) { nil }
+      let(:quoted_status) { nil }
       let(:visibility) { :public }
       let(:searchability) { :public }
       let(:alice) { Fabricate(:account, username: 'alice') }
-      let(:status) { Fabricate(:status, account: alice, thread: parent_status, visibility: visibility, searchability: searchability) }
+      let(:status) { Fabricate(:status, account: alice, thread: parent_status, quote_of_id: quoted_status&.id, visibility: visibility, searchability: searchability) }
 
       context 'with a simple case' do
         let(:bob) { Fabricate(:account, username: 'bob', domain: 'foo.bar', protocol: :activitypub, inbox_url: 'https://foo.bar/inbox') }
@@ -163,6 +164,15 @@ describe StatusReachFinder do
           it 'does not include the inbox of the replied-to account' do
             expect(subject.inboxes).to_not include 'https://foo.bar/inbox'
           end
+        end
+      end
+
+      context 'when it is a quote to a remote account' do
+        let(:bob) { Fabricate(:account, username: 'bob', domain: 'foo.bar', protocol: :activitypub, inbox_url: 'https://foo.bar/inbox') }
+        let(:quoted_status) { Fabricate(:status, account: bob) }
+
+        it 'includes the inbox of the quoted-to account' do
+          expect(subject.inboxes).to include 'https://foo.bar/inbox'
         end
       end
     end

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -373,6 +373,22 @@ RSpec.describe Status do
     end
   end
 
+  describe '.domain_blocks_map' do
+    subject { described_class.domain_blocks_map([status.account.domain], account) }
+
+    let(:status)  { Fabricate(:status, account: Fabricate(:account, domain: 'foo.bar', uri: 'https://foo.bar/status')) }
+    let(:account) { Fabricate(:account) }
+
+    it 'returns a hash' do
+      expect(subject).to be_a Hash
+    end
+
+    it 'contains true value' do
+      account.block_domain!(status.account.domain)
+      expect(subject[status.account.domain]).to be true
+    end
+  end
+
   describe '.favourites_map' do
     subject { described_class.favourites_map([status], account) }
 

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -217,6 +217,39 @@ RSpec.describe Status do
     end
   end
 
+  describe '#quote' do
+    let(:target_status) { Fabricate(:status) }
+    let(:quote) { true }
+
+    before do
+      Fabricate(:status_reference, status: subject, target_status: target_status, quote: quote)
+    end
+
+    context 'when quoting single' do
+      it 'get quote' do
+        expect(subject.quote).to_not be_nil
+        expect(subject.quote.id).to eq target_status.id
+      end
+    end
+
+    context 'when multiple quotes' do
+      it 'get quote' do
+        target2 = Fabricate(:status)
+        Fabricate(:status_reference, status: subject, quote: quote)
+        expect(subject.quote).to_not be_nil
+        expect([target_status.id, target2.id].include?(subject.quote.id)).to be true
+      end
+    end
+
+    context 'when no quote but reference' do
+      let(:quote) { false }
+
+      it 'get quote' do
+        expect(subject.quote).to be_nil
+      end
+    end
+  end
+
   describe '#content' do
     it 'returns the text of the status if it is not a reblog' do
       expect(subject.content).to eql subject.text
@@ -321,6 +354,22 @@ RSpec.describe Status do
     it 'contains true value' do
       account.mute_conversation!(status.conversation)
       expect(subject[status.conversation.id]).to be true
+    end
+  end
+
+  describe '.blocks_map' do
+    subject { described_class.blocks_map([status.account.id], account) }
+
+    let(:status)  { Fabricate(:status) }
+    let(:account) { Fabricate(:account) }
+
+    it 'returns a hash' do
+      expect(subject).to be_a Hash
+    end
+
+    it 'contains true value' do
+      account.block!(status.account)
+      expect(subject[status.account.id]).to be true
     end
   end
 

--- a/spec/policies/status_policy_spec.rb
+++ b/spec/policies/status_policy_spec.rb
@@ -167,6 +167,48 @@ RSpec.describe StatusPolicy, type: :model do
     end
   end
 
+  context 'with the permission of emoji_reaction?' do
+    permissions :emoji_reaction? do
+      it 'grants access when viewer is not blocked' do
+        follow         = Fabricate(:follow)
+        status.account = follow.target_account
+
+        expect(subject).to permit(follow.account, status)
+      end
+
+      it 'denies when viewer is blocked' do
+        block          = Fabricate(:block)
+        status.account = block.target_account
+
+        expect(subject).to_not permit(block.account, status)
+      end
+    end
+  end
+
+  context 'with the permission of quote?' do
+    permissions :quote? do
+      it 'grants access when viewer is not blocked' do
+        follow         = Fabricate(:follow)
+        status.account = follow.target_account
+
+        expect(subject).to permit(follow.account, status)
+      end
+
+      it 'denies when viewer is blocked' do
+        block          = Fabricate(:block)
+        status.account = block.target_account
+
+        expect(subject).to_not permit(block.account, status)
+      end
+
+      it 'denies when private visibility' do
+        status.visibility = :private
+
+        expect(subject).to_not permit(Fabricate(:account), status)
+      end
+    end
+  end
+
   context 'with the permission of update?' do
     permissions :update? do
       it 'grants access if owner' do

--- a/spec/serializers/activitypub/note_serializer_spec.rb
+++ b/spec/serializers/activitypub/note_serializer_spec.rb
@@ -15,12 +15,10 @@ describe ActivityPub::NoteSerializer do
   let!(:reply_by_account_visibility_direct) { Fabricate(:status, account: account, thread: parent, visibility: :direct) }
   let!(:referred) { nil }
   let!(:referred2) { nil }
-  let(:convert_to_quote) { false }
 
   before(:each) do
     parent.references << referred if referred.present?
     parent.references << referred2 if referred2.present?
-    account.user&.settings&.[]=('single_ref_to_quote', true) if convert_to_quote
     @serialization = ActiveModelSerializers::SerializableResource.new(parent, serializer: described_class, adapter: ActivityPub::Adapter)
   end
 
@@ -62,30 +60,6 @@ describe ActivityPub::NoteSerializer do
     it 'has as reference' do
       expect(subject['quoteUri']).to be_nil
       expect(subject['references']['first']['items']).to include referred.uri
-    end
-  end
-
-  context 'when has quote and convert setting' do
-    let(:referred) { Fabricate(:status) }
-    let(:convert_to_quote) { true }
-
-    it 'has as quote' do
-      expect(subject['quoteUri']).to_not be_nil
-      expect(subject['quoteUri']).to eq referred.uri
-      expect(subject['_misskey_quote']).to eq referred.uri
-      expect(subject['references']['first']['items']).to include referred.uri
-    end
-  end
-
-  context 'when has multiple references and convert setting' do
-    let(:referred) { Fabricate(:status) }
-    let(:referred2) { Fabricate(:status) }
-    let(:convert_to_quote) { true }
-
-    it 'has as quote' do
-      expect(subject['quoteUri']).to be_nil
-      expect(subject['references']['first']['items']).to include referred.uri
-      expect(subject['references']['first']['items']).to include referred2.uri
     end
   end
 end

--- a/spec/services/process_references_service_spec.rb
+++ b/spec/services/process_references_service_spec.rb
@@ -35,6 +35,10 @@ RSpec.describe ProcessReferencesService, type: :service do
         expect(subject.pluck(1)).to include 'RT'
         expect(notify?).to be true
       end
+
+      it 'not quote' do
+        expect(status.quote).to be_nil
+      end
     end
 
     context 'when multiple references' do

--- a/spec/services/process_references_service_spec.rb
+++ b/spec/services/process_references_service_spec.rb
@@ -244,6 +244,17 @@ RSpec.describe ProcessReferencesService, type: :service do
       end
     end
 
+    context 'when remove quote' do
+      let(:text) { "QT #{target_status_uri}" }
+      let(:new_text) { 'Hello' }
+
+      it 'post status' do
+        expect(subject.size).to eq 0
+        expect(status.quote).to be_nil
+        expect(notify?).to be false
+      end
+    end
+
     context 'when change reference' do
       let(:text) { "BT #{target_status_uri}" }
       let(:new_text) { "BT #{target_status2_uri}" }
@@ -251,6 +262,19 @@ RSpec.describe ProcessReferencesService, type: :service do
       it 'post status' do
         expect(subject.size).to eq 1
         expect(subject).to include target_status2.id
+        expect(notify?(target_status2.id)).to be true
+      end
+    end
+
+    context 'when change quote' do
+      let(:text) { "QT #{target_status_uri}" }
+      let(:new_text) { "QT #{target_status2_uri}" }
+
+      it 'post status' do
+        expect(subject.size).to eq 1
+        expect(subject).to include target_status2.id
+        expect(status.quote).to_not be_nil
+        expect(status.quote.id).to eq target_status2.id
         expect(notify?(target_status2.id)).to be true
       end
     end

--- a/spec/services/process_references_service_spec.rb
+++ b/spec/services/process_references_service_spec.rb
@@ -105,6 +105,34 @@ RSpec.describe ProcessReferencesService, type: :service do
       end
     end
 
+    context 'with quote as parameter and embed' do
+      let(:text) { "Hello QT #{target_status_uri}" }
+      let(:quote_urls) { [ActivityPub::TagManager.instance.uri_for(target_status)] }
+
+      it 'post status' do
+        expect(subject.size).to eq 1
+        expect(subject.pluck(0)).to include target_status.id
+        expect(subject.pluck(1)).to include 'QT'
+        expect(status.quote).to_not be_nil
+        expect(status.quote.id).to eq target_status.id
+        expect(notify?).to be true
+      end
+    end
+
+    context 'with quote as parameter but embed is not quote' do
+      let(:text) { "Hello RE #{target_status_uri}" }
+      let(:quote_urls) { [ActivityPub::TagManager.instance.uri_for(target_status)] }
+
+      it 'post status' do
+        expect(subject.size).to eq 1
+        expect(subject.pluck(0)).to include target_status.id
+        expect(subject.pluck(1)).to include 'QT'
+        expect(status.quote).to_not be_nil
+        expect(status.quote.id).to eq target_status.id
+        expect(notify?).to be true
+      end
+    end
+
     context 'with quote and reference' do
       let(:target_status2) { Fabricate(:status) }
       let(:target_status2_uri) { ActivityPub::TagManager.instance.uri_for(target_status2) }
@@ -291,6 +319,31 @@ RSpec.describe ProcessReferencesService, type: :service do
         expect(status.quote).to_not be_nil
         expect(status.quote.id).to eq target_status2.id
         expect(notify?(target_status2.id)).to be true
+      end
+    end
+
+    context 'when change quote to reference', pending: 'Will fix later' do
+      let(:text) { "QT #{target_status_uri}" }
+      let(:new_text) { "RT #{target_status_uri}" }
+
+      it 'post status' do
+        expect(subject.size).to eq 1
+        expect(subject).to include target_status.id
+        expect(status.quote).to be_nil
+        expect(notify?(target_status.id)).to be true
+      end
+    end
+
+    context 'when change reference to quote', pending: 'Will fix later' do
+      let(:text) { "RT #{target_status_uri}" }
+      let(:new_text) { "QT #{target_status_uri}" }
+
+      it 'post status' do
+        expect(subject.size).to eq 1
+        expect(subject).to include target_status.id
+        expect(status.quote).to_not be_nil
+        expect(status.quote.id).to eq target_status.id
+        expect(notify?(target_status.id)).to be true
       end
     end
   end

--- a/streaming/index.js
+++ b/streaming/index.js
@@ -801,8 +801,8 @@ const startServer = async () => {
 
       // reference_texts property is not working if ProcessReferencesWorker is
       // used on PostStatusService and so on. (Asynchronous processing)
-      const reference_texts = payload.reference_texts || [];
-      if (payload.reference_texts) {
+      const reference_texts = payload?.reference_texts || [];
+      if (payload && typeof payload.reference_texts !== 'undefined') {
         delete payload.reference_texts;
       }
 


### PR DESCRIPTION
Closes #49 

- [x] Status ID指定で表示できるようにする（コンテナを間に挟む）
- [x] 引用をAPIで取得できるようにする
  - [x] APIの動作確認
- [x] 引用のキャッシュ
- [x] 引用可能な投稿の公開範囲を検討 - `public`, `public_unlisted`, `unlisted`のみとする
- [x] 他サーバーから来た引用を、参照ではなく引用として受け入れられるようにする
- [x] 引用IDをコンポーネントに流し込む
- [x] 通知画面から引用を消す
- [x] フィルター対応（キーワード）
- [x] フィルター対応（投稿指定）
- [x] ミュート対応
- [x] ブロック対応
- [x] 不要コードの削除
- [x] 動作確認（通常）
- [x] 動作確認（画像１枚）
- [x] 動作確認（画像複数）
- [x] 動作確認（引用のネスト）
- [x] 動作確認（フィルター）
- [x] 動作確認（ミュート・ブロック）
- [x] 動作確認（フィルター・ミュートとストリーミング）
- [x] データベースマイグレーションの動作確認
- [x] もしあれば引用まわりのテストコード
- [x] 設定「自分の投稿の引用を許可する」
- [x] 設定「自分のローカルタイムラインに引用を表示」
- [x] 設定「自分のホームタイムラインに引用を表示」
- [x] 画面に引用メニュー（表示・非表示を判定するとか）