### PR TITLE
他サーバーからカスタム絵文字によるスタンプを受け取った時に、ライセンス情報を保存する＋ついでにテスト

### DIFF
--- a/app/lib/activitypub/activity/like.rb
+++ b/app/lib/activitypub/activity/like.rb
@@ -34,23 +34,11 @@ class ActivityPub::Activity::Like < ActivityPub::Activity
   def process_emoji_reaction
     return if !@original_status.account.local? && !Setting.receive_other_servers_emoji_reaction
 
+    # custom emoji
+    emoji = nil
     if emoji_tag.present?
-      return if emoji_tag['id'].blank? || emoji_tag['name'].blank? || emoji_tag['icon'].blank? || emoji_tag['icon']['url'].blank?
-
-      image_url = emoji_tag['icon']['url']
-      uri       = emoji_tag['id']
-      domain    = emoji_tag['domain'] || URI.split(uri)[2]
-
-      return if domain.blank?
-
-      domain = nil if domain == Rails.configuration.x.local_domain || domain == Rails.configuration.x.web_domain
-
-      emoji = CustomEmoji.find_or_create_by!(shortcode: shortcode, domain: domain) do |emoji_data|
-        emoji_data.uri              = uri
-        emoji_data.image_remote_url = image_url
-      end
-
-      Trends.statuses.register(@original_status)
+      emoji = process_emoji(emoji_tag)
+      return if emoji.nil?
     end
 
     reaction = nil
@@ -62,6 +50,7 @@ class ActivityPub::Activity::Like < ActivityPub::Activity
       reaction = @original_status.emoji_reactions.create!(account: @account, name: shortcode, custom_emoji: emoji, uri: @json['id'])
     end
 
+    Trends.statuses.register(@original_status)
     write_stream(reaction)
 
     if @original_status.account.local?
@@ -97,6 +86,43 @@ class ActivityPub::Activity::Like < ActivityPub::Activity
         @json['content']&.delete(':')
       end
     end
+  end
+
+  def process_emoji(tag)
+    return if skip_download?
+
+    custom_emoji_parser = ActivityPub::Parser::CustomEmojiParser.new(tag)
+
+    return if custom_emoji_parser.shortcode.blank? || custom_emoji_parser.image_remote_url.blank?
+
+    emoji = CustomEmoji.find_by(shortcode: custom_emoji_parser.shortcode, domain: @account.domain)
+
+    return unless emoji.nil? || custom_emoji_parser.image_remote_url != emoji.image_remote_url || (custom_emoji_parser.updated_at && custom_emoji_parser.updated_at >= emoji.updated_at)
+
+    domain = emoji_tag['domain'] || URI.split(custom_emoji_parser.uri)[2] || @account.domain
+    domain = nil if domain == Rails.configuration.x.local_domain || domain == Rails.configuration.x.web_domain
+
+    begin
+      emoji ||= CustomEmoji.new(
+        domain: domain,
+        shortcode: custom_emoji_parser.shortcode,
+        uri: custom_emoji_parser.uri,
+        is_sensitive: custom_emoji_parser.is_sensitive,
+        license: custom_emoji_parser.license
+      )
+      emoji.image_remote_url = custom_emoji_parser.image_remote_url
+      emoji.save
+    rescue Seahorse::Client::NetworkingError => e
+      Rails.logger.warn "Error storing emoji: #{e}"
+    end
+
+    emoji
+  end
+
+  def skip_download?
+    return @skip_download if defined?(@skip_download)
+
+    @skip_download ||= DomainBlock.reject_media?(@account.domain)
   end
 
   def misskey_favourite?

--- a/app/lib/activitypub/activity/like.rb
+++ b/app/lib/activitypub/activity/like.rb
@@ -39,7 +39,7 @@ class ActivityPub::Activity::Like < ActivityPub::Activity
 
       image_url = emoji_tag['icon']['url']
       uri       = emoji_tag['id']
-      domain    = URI.split(uri)[2]
+      domain    = emoji_tag['domain'] || URI.split(uri)[2]
 
       emoji = CustomEmoji.find_or_create_by!(shortcode: shortcode, domain: domain) do |emoji_data|
         emoji_data.uri              = uri

--- a/app/lib/activitypub/activity/like.rb
+++ b/app/lib/activitypub/activity/like.rb
@@ -41,6 +41,10 @@ class ActivityPub::Activity::Like < ActivityPub::Activity
       uri       = emoji_tag['id']
       domain    = emoji_tag['domain'] || URI.split(uri)[2]
 
+      return if domain.blank?
+
+      domain = nil if domain == Rails.configuration.x.local_domain || domain == Rails.configuration.x.web_domain
+
       emoji = CustomEmoji.find_or_create_by!(shortcode: shortcode, domain: domain) do |emoji_data|
         emoji_data.uri              = uri
         emoji_data.image_remote_url = image_url

--- a/app/lib/activitypub/activity/like.rb
+++ b/app/lib/activitypub/activity/like.rb
@@ -7,7 +7,7 @@ class ActivityPub::Activity::Like < ActivityPub::Activity
   def perform
     @original_status = status_from_uri(object_uri)
 
-    return if @original_status.nil? || delete_arrived_first?(@json['id']) || reject_favourite?
+    return if @original_status.nil? || delete_arrived_first?(@json['id']) || block_domain? || reject_favourite?
 
     if shortcode.nil? || !Setting.enable_emoji_reaction
       process_favourite
@@ -121,6 +121,10 @@ class ActivityPub::Activity::Like < ActivityPub::Activity
 
   def skip_download?(domain)
     DomainBlock.reject_media?(domain)
+  end
+
+  def block_domain?
+    DomainBlock.blocked?(@account.domain)
   end
 
   def misskey_favourite?

--- a/app/lib/activitypub/parser/custom_emoji_parser.rb
+++ b/app/lib/activitypub/parser/custom_emoji_parser.rb
@@ -30,6 +30,6 @@ class ActivityPub::Parser::CustomEmojiParser
   end
 
   def license
-    @json['license']
+    @json['license'] || @json['licence']
   end
 end

--- a/app/lib/activitypub/tag_manager.rb
+++ b/app/lib/activitypub/tag_manager.rb
@@ -46,9 +46,7 @@ class ActivityPub::TagManager
 
       account_status_url(target.account, target)
     when :emoji
-      return emoji_url(target) if object.uri.nil? || object.domain.nil?
-
-      object.uri
+      emoji_url(target)
     when :emoji_reaction
       emoji_reaction_url(target)
     when :flag

--- a/app/lib/activitypub/tag_manager.rb
+++ b/app/lib/activitypub/tag_manager.rb
@@ -46,7 +46,9 @@ class ActivityPub::TagManager
 
       account_status_url(target.account, target)
     when :emoji
-      emoji_url(target)
+      return emoji_url(target) if object.uri.nil? || object.domain.nil?
+
+      object.uri
     when :emoji_reaction
       emoji_reaction_url(target)
     when :flag

--- a/app/serializers/activitypub/emoji_serializer.rb
+++ b/app/serializers/activitypub/emoji_serializer.rb
@@ -10,11 +10,7 @@ class ActivityPub::EmojiSerializer < ActivityPub::Serializer
   has_one :icon, serializer: ActivityPub::ImageSerializer
 
   def id
-    if object.uri.nil? || object.domain.nil?
-      ActivityPub::TagManager.instance.uri_for(object)
-    else
-      object.uri
-    end
+    ActivityPub::TagManager.instance.uri_for(object)
   end
 
   def type

--- a/app/serializers/activitypub/emoji_serializer.rb
+++ b/app/serializers/activitypub/emoji_serializer.rb
@@ -5,7 +5,9 @@ class ActivityPub::EmojiSerializer < ActivityPub::Serializer
 
   context_extensions :emoji
 
-  attributes :id, :type, :domain, :name, :updated
+  attributes :id, :type, :domain, :name, :is_sensitive, :updated
+
+  attribute :license, if: -> { object.license.present? }
 
   has_one :icon, serializer: ActivityPub::ImageSerializer
 

--- a/app/serializers/activitypub/emoji_serializer.rb
+++ b/app/serializers/activitypub/emoji_serializer.rb
@@ -5,7 +5,7 @@ class ActivityPub::EmojiSerializer < ActivityPub::Serializer
 
   context_extensions :emoji
 
-  attributes :id, :type, :name, :updated
+  attributes :id, :type, :domain, :name, :updated
 
   has_one :icon, serializer: ActivityPub::ImageSerializer
 
@@ -15,6 +15,10 @@ class ActivityPub::EmojiSerializer < ActivityPub::Serializer
 
   def type
     'Emoji'
+  end
+
+  def domain
+    object.domain.presence || Rails.configuration.x.local_domain
   end
 
   def icon

--- a/app/serializers/activitypub/emoji_serializer.rb
+++ b/app/serializers/activitypub/emoji_serializer.rb
@@ -10,7 +10,11 @@ class ActivityPub::EmojiSerializer < ActivityPub::Serializer
   has_one :icon, serializer: ActivityPub::ImageSerializer
 
   def id
-    ActivityPub::TagManager.instance.uri_for(object)
+    if object.uri.nil? || object.domain.nil?
+      ActivityPub::TagManager.instance.uri_for(object)
+    else
+      object.uri
+    end
   end
 
   def type

--- a/spec/lib/activitypub/activity/like_spec.rb
+++ b/spec/lib/activitypub/activity/like_spec.rb
@@ -269,7 +269,7 @@ RSpec.describe ActivityPub::Activity::Like do
       subject.perform
     end
 
-    it 'does not create a favourite from sender to status', pending: 'considering spec' do
+    it 'does not create a favourite from sender to status' do
       expect(sender.favourited?(status)).to be false
     end
   end

--- a/spec/lib/activitypub/activity/like_spec.rb
+++ b/spec/lib/activitypub/activity/like_spec.rb
@@ -113,6 +113,50 @@ RSpec.describe ActivityPub::Activity::Like do
       end
     end
 
+    context 'with custom emoji but invalid id' do
+      let(:content) { 'ohagi' }
+      let(:tag) do
+        {
+          id: 'aaa',
+          type: 'Emoji',
+          icon: {
+            url: 'http://example.com/emoji.png',
+          },
+          name: 'tinking',
+        }
+      end
+
+      it 'create emoji reaction' do
+        expect(subject.count).to eq 0
+        expect(sender.favourited?(status)).to be false
+      end
+    end
+
+    context 'with custom emoji but local domain' do
+      let(:content) { 'ohagi' }
+      let(:tag) do
+        {
+          id: 'aaa',
+          type: 'Emoji',
+          domain: Rails.configuration.x.local_domain,
+          icon: {
+            url: 'http://example.com/emoji.png',
+          },
+          name: 'tinking',
+        }
+      end
+
+      it 'create emoji reaction' do
+        expect(subject.count).to eq 1
+        expect(subject.first.name).to eq 'ohagi'
+        expect(subject.first.account).to eq sender
+        expect(subject.first.custom_emoji).to_not be_nil
+        expect(subject.first.custom_emoji.shortcode).to eq 'ohagi'
+        expect(subject.first.custom_emoji.domain).to be_nil
+        expect(sender.favourited?(status)).to be false
+      end
+    end
+
     context 'when emoji reaction is disabled' do
       let(:content) { '😀' }
 

--- a/spec/lib/activitypub/activity/like_spec.rb
+++ b/spec/lib/activitypub/activity/like_spec.rb
@@ -29,6 +29,133 @@ RSpec.describe ActivityPub::Activity::Like do
     end
   end
 
+  describe '#perform when receive emoji reaction' do
+    subject do
+      described_class.new(json, sender).perform
+      EmojiReaction.where(status: status)
+    end
+
+    before do
+      stub_request(:get, 'http://example.com/emoji.png').to_return(body: attachment_fixture('emojo.png'))
+    end
+
+    let(:json) do
+      {
+        '@context': 'https://www.w3.org/ns/activitystreams',
+        id: 'foo',
+        type: 'Like',
+        actor: ActivityPub::TagManager.instance.uri_for(sender),
+        object: ActivityPub::TagManager.instance.uri_for(status),
+        content: content,
+        tag: tag,
+      }.with_indifferent_access
+    end
+    let(:content) { nil }
+    let(:tag) { nil }
+
+    context 'with unicode emoji' do
+      let(:content) { '😀' }
+
+      it 'create emoji reaction' do
+        expect(subject.count).to eq 1
+        expect(subject.first.name).to eq '😀'
+        expect(subject.first.account).to eq sender
+        expect(sender.favourited?(status)).to be false
+      end
+    end
+
+    context 'with custom emoji' do
+      let(:content) { 'ohagi' }
+      let(:tag) do
+        {
+          id: 'https://example.com/aaa',
+          type: 'Emoji',
+          icon: {
+            url: 'http://example.com/emoji.png',
+          },
+          name: 'tinking',
+        }
+      end
+
+      it 'create emoji reaction' do
+        expect(subject.count).to eq 1
+        expect(subject.first.name).to eq 'ohagi'
+        expect(subject.first.account).to eq sender
+        expect(subject.first.custom_emoji).to_not be_nil
+        expect(subject.first.custom_emoji.shortcode).to eq 'ohagi'
+        expect(subject.first.custom_emoji.domain).to eq 'example.com'
+        expect(sender.favourited?(status)).to be false
+      end
+    end
+
+    context 'with custom emoji and custom domain' do
+      let(:content) { 'ohagi' }
+      let(:tag) do
+        {
+          id: 'https://example.com/aaa',
+          type: 'Emoji',
+          domain: 'post.kmycode.net',
+          icon: {
+            url: 'http://example.com/emoji.png',
+          },
+          name: 'tinking',
+        }
+      end
+
+      it 'create emoji reaction' do
+        expect(subject.count).to eq 1
+        expect(subject.first.name).to eq 'ohagi'
+        expect(subject.first.account).to eq sender
+        expect(subject.first.custom_emoji).to_not be_nil
+        expect(subject.first.custom_emoji.shortcode).to eq 'ohagi'
+        expect(subject.first.custom_emoji.domain).to eq 'post.kmycode.net'
+        expect(sender.favourited?(status)).to be false
+      end
+    end
+
+    context 'when emoji reaction is disabled' do
+      let(:content) { '😀' }
+
+      before do
+        Form::AdminSettings.new(enable_emoji_reaction: false).save
+      end
+
+      it 'create emoji reaction' do
+        expect(subject.count).to eq 0
+        expect(sender.favourited?(status)).to be true
+      end
+    end
+
+    context 'when emoji reaction between other servers is disabled' do
+      let(:recipient) { Fabricate(:account, domain: 'narrow.com', uri: 'https://narrow.com/') }
+      let(:content) { '😀' }
+
+      before do
+        Form::AdminSettings.new(receive_other_servers_emoji_reaction: false).save
+      end
+
+      it 'create emoji reaction' do
+        expect(subject.count).to eq 0
+        expect(sender.favourited?(status)).to be false
+      end
+    end
+
+    context 'when emoji reaction between other servers is disabled but that status is local' do
+      let(:content) { '😀' }
+
+      before do
+        Form::AdminSettings.new(receive_other_servers_emoji_reaction: false).save
+      end
+
+      it 'create emoji reaction' do
+        expect(subject.count).to eq 1
+        expect(subject.first.name).to eq '😀'
+        expect(subject.first.account).to eq sender
+        expect(sender.favourited?(status)).to be false
+      end
+    end
+  end
+
   describe '#perform when domain_block' do
     subject { described_class.new(json, sender) }
 

--- a/spec/lib/activitypub/activity/like_spec.rb
+++ b/spec/lib/activitypub/activity/like_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe ActivityPub::Activity::Like do
     end
 
     context 'with custom emoji' do
-      let(:content) { 'ohagi' }
+      let(:content) { ':tinking:' }
       let(:tag) do
         {
           id: 'https://example.com/aaa',
@@ -79,17 +79,17 @@ RSpec.describe ActivityPub::Activity::Like do
 
       it 'create emoji reaction' do
         expect(subject.count).to eq 1
-        expect(subject.first.name).to eq 'ohagi'
+        expect(subject.first.name).to eq 'tinking'
         expect(subject.first.account).to eq sender
         expect(subject.first.custom_emoji).to_not be_nil
-        expect(subject.first.custom_emoji.shortcode).to eq 'ohagi'
+        expect(subject.first.custom_emoji.shortcode).to eq 'tinking'
         expect(subject.first.custom_emoji.domain).to eq 'example.com'
         expect(sender.favourited?(status)).to be false
       end
     end
 
     context 'with custom emoji and custom domain' do
-      let(:content) { 'ohagi' }
+      let(:content) { ':tinking:' }
       let(:tag) do
         {
           id: 'https://example.com/aaa',
@@ -104,17 +104,17 @@ RSpec.describe ActivityPub::Activity::Like do
 
       it 'create emoji reaction' do
         expect(subject.count).to eq 1
-        expect(subject.first.name).to eq 'ohagi'
+        expect(subject.first.name).to eq 'tinking'
         expect(subject.first.account).to eq sender
         expect(subject.first.custom_emoji).to_not be_nil
-        expect(subject.first.custom_emoji.shortcode).to eq 'ohagi'
+        expect(subject.first.custom_emoji.shortcode).to eq 'tinking'
         expect(subject.first.custom_emoji.domain).to eq 'post.kmycode.net'
         expect(sender.favourited?(status)).to be false
       end
     end
 
     context 'with custom emoji but invalid id' do
-      let(:content) { 'ohagi' }
+      let(:content) { ':tinking:' }
       let(:tag) do
         {
           id: 'aaa',
@@ -127,13 +127,18 @@ RSpec.describe ActivityPub::Activity::Like do
       end
 
       it 'create emoji reaction' do
-        expect(subject.count).to eq 0
+        expect(subject.count).to eq 1
+        expect(subject.first.name).to eq 'tinking'
+        expect(subject.first.account).to eq sender
+        expect(subject.first.custom_emoji).to_not be_nil
+        expect(subject.first.custom_emoji.shortcode).to eq 'tinking'
+        expect(subject.first.custom_emoji.domain).to eq 'example.com'
         expect(sender.favourited?(status)).to be false
       end
     end
 
     context 'with custom emoji but local domain' do
-      let(:content) { 'ohagi' }
+      let(:content) { ':tinking:' }
       let(:tag) do
         {
           id: 'aaa',
@@ -148,10 +153,10 @@ RSpec.describe ActivityPub::Activity::Like do
 
       it 'create emoji reaction' do
         expect(subject.count).to eq 1
-        expect(subject.first.name).to eq 'ohagi'
+        expect(subject.first.name).to eq 'tinking'
         expect(subject.first.account).to eq sender
         expect(subject.first.custom_emoji).to_not be_nil
-        expect(subject.first.custom_emoji.shortcode).to eq 'ohagi'
+        expect(subject.first.custom_emoji.shortcode).to eq 'tinking'
         expect(subject.first.custom_emoji.domain).to be_nil
         expect(sender.favourited?(status)).to be false
       end

--- a/spec/lib/activitypub/activity/like_spec.rb
+++ b/spec/lib/activitypub/activity/like_spec.rb
@@ -167,6 +167,44 @@ RSpec.describe ActivityPub::Activity::Like do
       end
     end
 
+    context 'with unicode emoji and reject_media enabled' do
+      let(:content) { '😀' }
+
+      before do
+        Fabricate(:domain_block, domain: 'example.com', severity: :noop, reject_media: true)
+      end
+
+      it 'create emoji reaction' do
+        expect(subject.count).to eq 1
+        expect(subject.first.name).to eq '😀'
+        expect(subject.first.account).to eq sender
+        expect(sender.favourited?(status)).to be false
+      end
+    end
+
+    context 'with custom emoji and reject_media enabled' do
+      let(:content) { ':tinking:' }
+      let(:tag) do
+        {
+          id: 'https://example.com/aaa',
+          type: 'Emoji',
+          icon: {
+            url: 'http://example.com/emoji.png',
+          },
+          name: 'tinking',
+        }
+      end
+
+      before do
+        Fabricate(:domain_block, domain: 'example.com', severity: :noop, reject_media: true)
+      end
+
+      it 'create emoji reaction' do
+        expect(subject.count).to eq 0
+        expect(sender.favourited?(status)).to be false
+      end
+    end
+
     context 'when emoji reaction is disabled' do
       let(:content) { '😀' }
 

--- a/spec/lib/activitypub/activity/like_spec.rb
+++ b/spec/lib/activitypub/activity/like_spec.rb
@@ -74,6 +74,7 @@ RSpec.describe ActivityPub::Activity::Like do
             url: 'http://example.com/emoji.png',
           },
           name: 'tinking',
+          license: 'Everyone but Ohagi',
         }
       end
 
@@ -85,6 +86,10 @@ RSpec.describe ActivityPub::Activity::Like do
         expect(subject.first.custom_emoji.shortcode).to eq 'tinking'
         expect(subject.first.custom_emoji.domain).to eq 'example.com'
         expect(sender.favourited?(status)).to be false
+      end
+
+      it 'custom emoji license is saved' do
+        expect(subject.first.custom_emoji.license).to eq 'Everyone but Ohagi'
       end
     end
 


### PR DESCRIPTION
Closes #64 

- [x] テスト作成
- [x] 他サーバーからのスタンプについて、ライセンス情報を取り込む

※`ActivityPub::EmojiSerializer`に`domain`プロパティを追加。現行ではIDをURLとみなしてそこから抽出しているが、vivaldi.netのようにWebとドメインが異なるケースを考慮