### PR TITLE
Add: カスタム絵文字の専用編集画面／Fix: リモートの絵文字をローカルにコピー時、ライセンス情報が消失する問題

### DIFF
--- a/app/controllers/admin/custom_emojis_controller.rb
+++ b/app/controllers/admin/custom_emojis_controller.rb
@@ -2,6 +2,8 @@
 
 module Admin
   class CustomEmojisController < BaseController
+    before_action :set_custom_emoji, only: [:edit, :update]
+
     def index
       authorize :custom_emoji, :index?
 
@@ -15,6 +17,10 @@ module Admin
       @custom_emoji = CustomEmoji.new
     end
 
+    def edit
+      authorize :custom_emoji, :create?
+    end
+
     def create
       authorize :custom_emoji, :create?
 
@@ -23,6 +29,19 @@ module Admin
       if @custom_emoji.save
         log_action :create, @custom_emoji
         redirect_to admin_custom_emojis_path, notice: I18n.t('admin.custom_emojis.created_msg')
+      else
+        render :new
+      end
+    end
+
+    def update
+      authorize :custom_emoji, :create?
+
+      @custom_emoji.assign_attributes(update_params)
+
+      if @custom_emoji.save
+        log_action :create, @custom_emoji
+        redirect_to admin_custom_emojis_path(filter_params), notice: I18n.t('admin.custom_emojis.updated_msg')
       else
         render :new
       end
@@ -43,8 +62,16 @@ module Admin
 
     private
 
+    def set_custom_emoji
+      @custom_emoji = CustomEmoji.find(params[:id])
+    end
+
     def resource_params
       params.require(:custom_emoji).permit(:shortcode, :image, :visible_in_picker)
+    end
+
+    def update_params
+      params.require(:custom_emoji).permit(:visible_in_picker, :aliases_raw, :license)
     end
 
     def filtered_custom_emojis

--- a/app/controllers/admin/custom_emojis_controller.rb
+++ b/app/controllers/admin/custom_emojis_controller.rb
@@ -67,7 +67,7 @@ module Admin
     end
 
     def resource_params
-      params.require(:custom_emoji).permit(:shortcode, :image, :visible_in_picker)
+      params.require(:custom_emoji).permit(:shortcode, :image, :visible_in_picker, :aliases_raw, :license)
     end
 
     def update_params
@@ -101,7 +101,7 @@ module Admin
     end
 
     def form_custom_emoji_batch_params
-      params.require(:form_custom_emoji_batch).permit(:action, :category_id, :category_name, :aliases_raw, custom_emoji_ids: [])
+      params.require(:form_custom_emoji_batch).permit(:action, :category_id, :category_name, custom_emoji_ids: [])
     end
   end
 end

--- a/app/models/custom_emoji.rb
+++ b/app/models/custom_emoji.rb
@@ -70,7 +70,13 @@ class CustomEmoji < ApplicationRecord
   end
 
   def copy!
-    copy = self.class.find_or_initialize_by(domain: nil, shortcode: shortcode)
+    copy = self.class.find_or_initialize_by(
+      domain: nil,
+      shortcode: shortcode,
+      license: license,
+      aliases: aliases,
+      is_sensitive: is_sensitive
+    )
     copy.image = image
     copy.tap(&:save!)
   end

--- a/app/models/form/custom_emoji_batch.rb
+++ b/app/models/form/custom_emoji_batch.rb
@@ -6,7 +6,7 @@ class Form::CustomEmojiBatch
   include AccountableConcern
 
   attr_accessor :custom_emoji_ids, :action, :current_account,
-                :category_id, :category_name, :aliases_raw, :visible_in_picker
+                :category_id, :category_name, :visible_in_picker
 
   def save
     case action
@@ -43,8 +43,7 @@ class Form::CustomEmojiBatch
                end
 
     custom_emojis.each do |custom_emoji|
-      new_aliases_raw = (aliases_raw.presence || custom_emoji.aliases_raw)
-      custom_emoji.update(category_id: category&.id, aliases_raw: new_aliases_raw)
+      custom_emoji.update(category_id: category&.id)
       log_action :update, custom_emoji
     end
   end

--- a/app/views/admin/custom_emojis/_custom_emoji.html.haml
+++ b/app/views/admin/custom_emojis/_custom_emoji.html.haml
@@ -7,11 +7,16 @@
 
     .batch-table__row__content__text
       %samp= ":#{custom_emoji.shortcode}:"
+      = link_to safe_join([fa_icon('pencil'), t('admin.custom_emojis.edit.label')]), edit_admin_custom_emoji_path(custom_emoji, local: params[:local], remote: params[:remote], shortcode: params[:shortcode], by_domain: params[:by_domain]), method: :get, class: 'table-action-link'
 
       - if custom_emoji.local?
         %span.information-badge= custom_emoji.category&.name || t('admin.custom_emojis.uncategorized')
+      - if custom_emoji.aliases_raw.present?
         %br/
-        %span= custom_emoji.aliases_raw
+        %span.neutral-hint= custom_emoji.aliases_raw
+      - if custom_emoji.license.present?
+        %br/
+        %span= custom_emoji.license
 
     .batch-table__row__content__extra
       - if custom_emoji.local?

--- a/app/views/admin/custom_emojis/edit.html.haml
+++ b/app/views/admin/custom_emojis/edit.html.haml
@@ -1,0 +1,39 @@
+- content_for :page_title do
+  = t('.title')
+
+= simple_form_for @custom_emoji, url: admin_custom_emoji_path(@custom_emoji.id), method: :put do |f|
+  = render 'shared/error_messages', object: @custom_emoji
+  - CustomEmojiFilter::KEYS.each do |key|
+    = hidden_field_tag key, params[key] if params[key].present?
+
+  %h4= t('admin.custom_emojis.shortcode')
+
+  .fields-group
+    %samp= @custom_emoji.shortcode
+
+  - if !@custom_emoji.local?
+    %h4= t('admin.custom_emojis.domain')
+
+    .fields-group
+      %samp= @custom_emoji.domain
+
+  - if @custom_emoji.local?
+    %h4= t('admin.custom_emojis.edit.label')
+
+    .fields-group
+      = f.input :visible_in_picker, as: :boolean, wrapper: :with_label, label: t('admin.custom_emojis.visible_in_picker')
+
+    .fields-group
+      = f.input :aliases_raw, wrapper: :with_label, kmyblue: true, label: t('admin.custom_emojis.aliases'), hint: t('admin.custom_emojis.aliases_hint')
+
+    .fields-group
+      = f.input :license, wrapper: :with_label, kmyblue: true, label: t('admin.custom_emojis.license'), hint: t('admin.custom_emojis.license_hint')
+
+    .actions
+      = f.button :button, t('generic.save_changes'), type: :submit
+
+  - elsif @custom_emoji.license.present?
+    %h4= t('admin.custom_emojis.license')
+
+    .fields-group
+      %p= @custom_emoji.license

--- a/app/views/admin/custom_emojis/edit.html.haml
+++ b/app/views/admin/custom_emojis/edit.html.haml
@@ -6,6 +6,9 @@
   - CustomEmojiFilter::KEYS.each do |key|
     = hidden_field_tag key, params[key] if params[key].present?
 
+  .fields-group
+    = custom_emoji_tag(@custom_emoji)
+
   %h4= t('admin.custom_emojis.shortcode')
 
   .fields-group

--- a/app/views/admin/custom_emojis/index.html.haml
+++ b/app/views/admin/custom_emojis/index.html.haml
@@ -75,12 +75,6 @@
               .label_input
                 = f.text_field :category_name, class: 'string optional', placeholder: t('admin.custom_emojis.create_new_category'), 'aria-label': t('admin.custom_emojis.create_new_category')
 
-        .fields-row
-          .fields-group.fields-row__column
-            .input.string.optional
-              .label_input
-                = f.text_field :aliases_raw, class: 'string optional', placeholder: 'Alias names', 'aria-label': 'Alias names'
-
     .batch-table__body
       - if @custom_emojis.empty?
         = nothing_here 'nothing-here--under-tabs'

--- a/app/views/admin/custom_emojis/new.html.haml
+++ b/app/views/admin/custom_emojis/new.html.haml
@@ -6,8 +6,18 @@
 
   .fields-group
     = f.input :shortcode, wrapper: :with_label, label: t('admin.custom_emojis.shortcode'), hint: t('admin.custom_emojis.shortcode_hint')
+
   .fields-group
     = f.input :image, wrapper: :with_label, input_html: { accept: CustomEmoji::IMAGE_MIME_TYPES.join(' ') }, hint: t('admin.custom_emojis.image_hint', size: number_to_human_size(CustomEmoji::LIMIT))
+
+  .fields-group
+    = f.input :visible_in_picker, as: :boolean, wrapper: :with_label, label: t('admin.custom_emojis.visible_in_picker')
+
+  .fields-group
+    = f.input :aliases_raw, wrapper: :with_label, kmyblue: true, label: t('admin.custom_emojis.aliases'), hint: t('admin.custom_emojis.aliases_hint')
+
+  .fields-group
+    = f.input :license, wrapper: :with_label, kmyblue: true, label: t('admin.custom_emojis.license'), hint: t('admin.custom_emojis.license_hint')
 
   .actions
     = f.button :button, t('admin.custom_emojis.upload'), type: :submit

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -316,6 +316,8 @@ en:
       updated_msg: Announcement successfully updated!
     critical_update_pending: Critical update pending
     custom_emojis:
+      aliases: Alias names
+      aliases_hint: When searching within the pictogram picker, you can search not only by short code, but also by alias name. You can specify multiple alias names by separating them with "," (comma).
       assign_category: Assign category
       by_domain: Domain
       copied_msg: Successfully created local copy of the emoji
@@ -328,11 +330,17 @@ en:
       disable: Disable
       disabled: Disabled
       disabled_msg: Successfully disabled that emoji
+      domain: Domain
+      edit:
+        label: Edit
+        title: Edit custom emoji
       emoji: Emoji
       enable: Enable
       enabled: Enabled
       enabled_msg: Successfully enabled that emoji
       image_hint: PNG or GIF up to %{size}
+      license: License
+      license_hint: Set license information for custom pictograms. However, many servers do not support the federation of license information, and Misskey also supports license information for local pictograms, but does not reference license information from other servers. Consider that licenses may be ignored.
       list: List
       listed: Listed
       new:
@@ -349,6 +357,7 @@ en:
       update_failed_msg: Could not update that emoji
       updated_msg: Emoji successfully updated!
       upload: Upload
+      visible_in_picker: Visible in emoji picker
     dashboard:
       active_users: active users
       interactions: interactions

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -313,6 +313,8 @@ ja:
       updated_msg: お知らせを更新しました
     critical_update_pending: 重要な更新が保留中です
     custom_emojis:
+      aliases: エイリアス名
+      aliases_hint: 絵文字ピッカー内で検索する際、ショートコードだけでなくエイリアス名でも検索できます。「,」（カンマ）で区切ることで、複数指定が可能です。
       assign_category: カテゴリーを割り当て
       by_domain: ドメイン
       copied_msg: 絵文字のコピーをローカルに作成しました
@@ -325,11 +327,17 @@ ja:
       disable: 無効化
       disabled: 無効
       disabled_msg: 絵文字を無効化しました
+      domain: ドメイン
+      edit:
+        label: 編集
+        title: カスタム絵文字の編集
       emoji: 絵文字
       enable: 有効化
       enabled: 有効
       enabled_msg: 絵文字を有効化しました
       image_hint: '%{size}までのPNGまたはGIF画像を利用できます'
+      license: ライセンス
+      license_hint: カスタム絵文字のライセンス情報を設定します。ただしライセンス情報の連合に対応していないサーバーも多く、Misskeyもローカル絵文字のライセンス情報には対応しますが他のサーバーのライセンス情報は参照しません。ライセンスは無視される場合があることを考慮してください。
       list: 表示
       listed: 表示
       new:
@@ -346,6 +354,7 @@ ja:
       update_failed_msg: 絵文字を更新できませんでした
       updated_msg: 絵文字の更新に成功しました！
       upload: アップロード
+      visible_in_picker: 絵文字ピッカーで表示
     dashboard:
       active_users: アクティブユーザー
       interactions: 交流

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -167,7 +167,7 @@ namespace :admin do
     resource :role, only: [:show, :update], controller: 'users/roles'
   end
 
-  resources :custom_emojis, only: [:index, :new, :create] do
+  resources :custom_emojis, only: [:index, :new, :create, :edit, :update] do
     collection do
       post :batch
     end


### PR DESCRIPTION
Closes #20, #106

- [x] 新しい編集画面を作成
- [x] 古いフォームを削除
- [x] 編集画面に絵文字画像を追加