### PR TITLE
Fix: ブーストが１つでもあると投稿のエクスポート時にエラーが出る問題

### DIFF
--- a/app/services/concerns/payloadable.rb
+++ b/app/services/concerns/payloadable.rb
@@ -16,8 +16,9 @@ module Payloadable
     always_sign = options.delete(:always_sign)
     payload     = ActiveModelSerializers::SerializableResource.new(record, options.merge(serializer: serializer, adapter: ActivityPub::Adapter)).as_json
     object      = record.respond_to?(:virtual_object) ? record.virtual_object : record
+    bearcap     = object.is_a?(String) && record.respond_to?(:type) && (record.type == 'Create' || record.type == 'Update')
 
-    if ((object.respond_to?(:sign?) && object.sign?) && signer && (always_sign || signing_enabled?)) || object.is_a?(String)
+    if ((object.respond_to?(:sign?) && object.sign?) && signer && (always_sign || signing_enabled?)) || bearcap
       ActivityPub::LinkedDataSignature.new(payload).sign!(signer, sign_with: sign_with)
     else
       payload

--- a/spec/services/backup_service_spec.rb
+++ b/spec/services/backup_service_spec.rb
@@ -9,9 +9,10 @@ RSpec.describe BackupService, type: :service do
   let!(:attachment)     { Fabricate(:media_attachment, account: user.account) }
   let!(:status)         { Fabricate(:status, account: user.account, text: 'Hello', visibility: :public, media_attachments: [attachment]) }
   let!(:private_status) { Fabricate(:status, account: user.account, text: 'secret', visibility: :private) }
+  let!(:limited_status) { Fabricate(:status, account: user.account, text: 'sec mutual', visibility: :limited, limited_scope: :mutual) }
+  let!(:reblog_status)  { Fabricate(:status, account: user.account, reblog_of_id: Fabricate(:status).id) }
   let!(:favourite)      { Fabricate(:favourite, account: user.account) }
   let!(:bookmark)       { Fabricate(:bookmark, account: user.account) }
-  let!(:reblog)         { Fabricate(:status, account: user.account, reblog_of_id: Fabricate(:status).id) }
   let!(:backup)         { Fabricate(:backup, user: user) }
 
   def read_zip_file(backup, filename)
@@ -61,11 +62,12 @@ RSpec.describe BackupService, type: :service do
     aggregate_failures do
       expect(json['@context']).to_not be_nil
       expect(json['type']).to eq 'OrderedCollection'
-      expect(json['totalItems']).to eq 3
+      expect(json['totalItems']).to eq 4
       expect(json['orderedItems'][0]['@context']).to be_nil
       expect(json['orderedItems'][0]).to include_create_item(status)
       expect(json['orderedItems'][1]).to include_create_item(private_status)
-      expect(json['orderedItems'][2]).to include_announce_item(reblog)
+      expect(json['orderedItems'][2]).to include_create_item(limited_status)
+      expect(json['orderedItems'][3]).to include_announce_item(reblog_status)
     end
   end
 

--- a/spec/services/backup_service_spec.rb
+++ b/spec/services/backup_service_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe BackupService, type: :service do
   let!(:private_status) { Fabricate(:status, account: user.account, text: 'secret', visibility: :private) }
   let!(:favourite)      { Fabricate(:favourite, account: user.account) }
   let!(:bookmark)       { Fabricate(:bookmark, account: user.account) }
+  let!(:reblog)         { Fabricate(:status, account: user.account, reblog_of_id: Fabricate(:status).id) }
   let!(:backup)         { Fabricate(:backup, user: user) }
 
   def read_zip_file(backup, filename)
@@ -60,10 +61,11 @@ RSpec.describe BackupService, type: :service do
     aggregate_failures do
       expect(json['@context']).to_not be_nil
       expect(json['type']).to eq 'OrderedCollection'
-      expect(json['totalItems']).to eq 2
+      expect(json['totalItems']).to eq 3
       expect(json['orderedItems'][0]['@context']).to be_nil
       expect(json['orderedItems'][0]).to include_create_item(status)
       expect(json['orderedItems'][1]).to include_create_item(private_status)
+      expect(json['orderedItems'][2]).to include_announce_item(reblog)
     end
   end
 
@@ -96,6 +98,13 @@ RSpec.describe BackupService, type: :service do
         'id' => ActivityPub::TagManager.instance.uri_for(status),
         'content' => "<p>#{status.text}</p>",
       }),
+    })
+  end
+
+  def include_announce_item(status)
+    include({
+      'type' => 'Announce',
+      'object' => ActivityPub::TagManager.instance.uri_for(status.reblog),
     })
   end
 end


### PR DESCRIPTION
`BackupService`がエラーで落ちる問題に対処

Bearcap処理まわりをいじったので、以下の動作確認が必要

- [x] サークル投稿を行ったとき、ペイロードに`signatureValue`が付加されているか
- [x] LTSでも確認