### PR TITLE
Fix: #137 ローカルのカスタム絵文字に`remote_url`が設定されるバグを修正したのに伴う、既存のデータから削除するマイグレ…

### DIFF
--- a/db/post_migrate/20231021005339_remove_remote_uri_from_local_custom_emojis.rb
+++ b/db/post_migrate/20231021005339_remove_remote_uri_from_local_custom_emojis.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require Rails.root.join('lib', 'mastodon', 'migration_helpers')
+
+class RemoveRemoteUriFromLocalCustomEmojis < ActiveRecord::Migration[7.0]
+  include Mastodon::MigrationHelpers
+
+  disable_ddl_transaction!
+
+  class CustomEmoji < ApplicationRecord; end
+
+  def up
+    safety_assured do
+      CustomEmoji.transaction do
+        CustomEmoji.where(domain: nil).update_all(image_remote_url: nil, uri: nil) # rubocop:disable Rails/SkipsModelValidations
+      end
+    end
+  end
+
+  def down; end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_09_235215) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_21_005339) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
…ーションコード

Closes #137

ローカル環境のせいかもしれないが、LTSでやろうとすると存在しないはずのカラムが`Schema.rb`に追加された。
問題はないと思うが安全を取ってLTS利用者には手動でのSQL発行を指示しようと思う