### PR TITLE
Fix: #162 編集／他のサーバーからの編集で、フォローしていない相手からのメンションに関するNGワードに対応

### DIFF
--- a/app/services/activitypub/process_status_update_service.rb
+++ b/app/services/activitypub/process_status_update_service.rb
@@ -5,6 +5,8 @@ class ActivityPub::ProcessStatusUpdateService < BaseService
   include Redisable
   include Lockable
 
+  class AbortError < ::StandardError; end
+
   def call(status, activity_json, object_json, request_id: nil)
     raise ArgumentError, 'Status has unsaved changes' if status.changed?
 
@@ -31,6 +33,9 @@ class ActivityPub::ProcessStatusUpdateService < BaseService
     end
 
     @status
+  rescue AbortError
+    @status.reload
+    @status
   end
 
   private
@@ -46,6 +51,7 @@ class ActivityPub::ProcessStatusUpdateService < BaseService
         update_poll!
         update_immediate_attributes!
         update_metadata!
+        validate_status_mentions!
         create_edits!
       end
 
@@ -158,6 +164,15 @@ class ActivityPub::ProcessStatusUpdateService < BaseService
 
   def valid_status?
     !Admin::NgWord.reject?("#{@status_parser.spoiler_text}\n#{@status_parser.text}") && !Admin::NgWord.hashtag_reject?(@raw_tags.size)
+  end
+
+  def validate_status_mentions!
+    raise AbortError if mention_to_stranger? && Admin::NgWord.stranger_mention_reject?("#{@status.spoiler_text}\n#{@status.text}")
+  end
+
+  def mention_to_stranger?
+    @status.mentions.map(&:account).to_a.any? { |mentioned_account| mentioned_account.id != @status.account.id && !mentioned_account.following?(@status.account) } ||
+      (@status.thread.present? && @status.thread.account.id != @status.account.id && !@status.thread.account.following?(@status.account))
   end
 
   def update_immediate_attributes!

--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -214,7 +214,7 @@ class PostStatusService < BaseService
   end
 
   def mention_to_stranger?
-    @status.mentions.map(&:account).to_a.any? { |mentioned_account| mentioned_account.id != @account && !mentioned_account.following?(@account) } ||
+    @status.mentions.map(&:account).to_a.any? { |mentioned_account| mentioned_account.id != @account.id && !mentioned_account.following?(@account) } ||
       (@in_reply_to && @in_reply_to.account.id != @account.id && !@in_reply_to.account.following?(@account))
   end
 

--- a/spec/services/post_status_service_spec.rb
+++ b/spec/services/post_status_service_spec.rb
@@ -510,6 +510,26 @@ RSpec.describe PostStatusService, type: :service do
       expect(status).to be_persisted
       expect(status.text).to eq text
     end
+
+    it 'using hashtag under limit' do
+      account = Fabricate(:account)
+      text = '#a #b'
+      Form::AdminSettings.new(post_hash_tags_max: 2).save
+
+      status = subject.call(account, text: text)
+
+      expect(status).to be_persisted
+      expect(status.tags.count).to eq 2
+      expect(status.text).to eq text
+    end
+
+    it 'using hashtag over limit' do
+      account = Fabricate(:account)
+      text = '#a #b #c'
+      Form::AdminSettings.new(post_hash_tags_max: 2).save
+
+      expect { subject.call(account, text: text) }.to raise_error Mastodon::ValidationError
+    end
   end
 
   def create_status_with_options(**options)


### PR DESCRIPTION
Closes #162
Closes #44

テストは問題なく通っているが、念のためサーバーテストもしたい

- [x] 他サーバーからメンションあり＋NGワードのない編集
- [x] 他サーバーからメンションあり＋NGワード含む編集
- [x] 自分のサーバーでメンションあり＋NGワードのない編集
- [x] 自分のサーバーでメンションあり＋NGワード含む編集