### PR TITLE
Fix: #217 スタンプ利用可能なソフトウェア名から`kmyblue`を削除

### DIFF
--- a/app/models/instance_info.rb
+++ b/app/models/instance_info.rb
@@ -22,7 +22,6 @@ class InstanceInfo < ApplicationRecord
     firefish
     renedon
     fedibird
-    kmyblue
     pleroma
     akkoma
   ).freeze


### PR DESCRIPTION
Closes #217 