### PR TITLE
Add: #87 フォロワーのみに購読を許可する設定

### DIFF
--- a/app/lib/account_statuses_filter.rb
+++ b/app/lib/account_statuses_filter.rb
@@ -44,7 +44,7 @@ class AccountStatusesFilter
   private
 
   def initial_scope
-    if (suspended? || (domain_block&.reject_send_dissubscribable && @account.dissubscribable)) || domain_block&.reject_send_media || blocked?
+    if (suspended? || (domain_block&.reject_send_dissubscribable && !@account.all_subscribable?)) || domain_block&.reject_send_media || blocked?
       Status.none
     elsif anonymous?
       account.statuses.where(visibility: %i(public unlisted public_unlisted))

--- a/app/lib/activitypub/tag_manager.rb
+++ b/app/lib/activitypub/tag_manager.rb
@@ -236,7 +236,14 @@ class ActivityPub::TagManager
   end
 
   def subscribable_by(account)
-    account.dissubscribable ? [] : [COLLECTIONS[:public]]
+    case account.subscribtion_policy
+    when :allow
+      [COLLECTIONS[:public]]
+    when :followers_only
+      [account_followers_url(account)]
+    else
+      []
+    end
   end
 
   def searchable_by(status)

--- a/app/lib/status_reach_finder.rb
+++ b/app/lib/status_reach_finder.rb
@@ -195,7 +195,7 @@ class StatusReachFinder
       blocks = DomainBlock.where(domain: nil)
       blocks = blocks.or(DomainBlock.where(reject_send_not_public_searchability: true)) if status.compute_searchability != 'public'
       blocks = blocks.or(DomainBlock.where(reject_send_public_unlisted: true)) if status.public_unlisted_visibility?
-      blocks = blocks.or(DomainBlock.where(reject_send_dissubscribable: true)) if status.account.dissubscribable
+      blocks = blocks.or(DomainBlock.where(reject_send_dissubscribable: true)) unless status.account.all_subscribable?
       blocks = blocks.or(DomainBlock.where(reject_send_media: true)) if status.with_media?
       blocks = blocks.or(DomainBlock.where(reject_send_sensitive: true)) if (status.with_media? && status.sensitive) || status.spoiler_text?
       blocks.pluck(:domain).uniq

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -52,9 +52,9 @@
 #  requested_review_at           :datetime
 #  group_allow_private_message   :boolean
 #  searchability                 :integer          default("direct"), not null
-#  dissubscribable               :boolean          default(FALSE), not null
 #  settings                      :jsonb
 #  indexable                     :boolean          default(FALSE), not null
+#  master_settings               :jsonb
 #
 
 class Account < ApplicationRecord
@@ -88,6 +88,7 @@ class Account < ApplicationRecord
   include AccountSearch
   include AccountStatusesSearch
   include AccountOtherSettings
+  include AccountMasterSettings
 
   enum protocol: { ostatus: 0, activitypub: 1 }
   enum suspension_origin: { local: 0, remote: 1 }, _prefix: true

--- a/app/models/concerns/account_master_settings.rb
+++ b/app/models/concerns/account_master_settings.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module AccountMasterSettings
+  extend ActiveSupport::Concern
+
+  included do
+    def subscribtion_policy
+      return master_settings['subscribtion_policy']&.to_sym || :allow if master_settings.present?
+
+      # allow, followers_only, block
+      :allow
+    end
+
+    def all_subscribable?
+      subscribtion_policy == :allow
+    end
+
+    def public_master_settings
+      {
+        'subscribtion_policy' => subscribtion_policy,
+      }
+    end
+  end
+end

--- a/app/models/concerns/account_other_settings.rb
+++ b/app/models/concerns/account_other_settings.rb
@@ -98,7 +98,7 @@ module AccountOtherSettings
         'link_preview' => link_preview?,
         'allow_quote' => allow_quote?,
         'emoji_reaction_policy' => Setting.enable_emoji_reaction ? emoji_reaction_policy : :block,
-      }
+      }.merge(public_master_settings)
       config = config.merge(settings) if settings.present?
       config
     end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -320,7 +320,7 @@ class Status < ApplicationRecord
   end
 
   def dtl?
-    tags.where(name: DTL_TAG).exists?
+    (%w(public public_unlisted login).include?(visibility) || (unlisted_visibility? && public_searchability?)) && tags.where(name: DTL_TAG).exists?
   end
 
   def emojis

--- a/app/policies/status_policy.rb
+++ b/app/policies/status_policy.rb
@@ -131,7 +131,7 @@ class StatusPolicy < ApplicationPolicy
       else
         (@domain_block.reject_send_not_public_searchability && status.compute_searchability != 'public') ||
           (@domain_block.reject_send_public_unlisted && status.public_unlisted_visibility?) ||
-          (@domain_block.reject_send_dissubscribable && status.account.dissubscribable) ||
+          (@domain_block.reject_send_dissubscribable && !status.account.all_subscribable?) ||
           (@domain_block.detect_invalid_subscription && status.public_unlisted_visibility? && status.account.user&.setting_reject_public_unlisted_subscription) ||
           (@domain_block.detect_invalid_subscription && status.public_visibility? && status.account.user&.setting_reject_unlisted_subscription) ||
           (@domain_block.reject_send_media && status.with_media?) ||

--- a/app/serializers/rest/account_serializer.rb
+++ b/app/serializers/rest/account_serializer.rb
@@ -112,7 +112,7 @@ class REST::AccountSerializer < ActiveModel::Serializer
   end
 
   def subscribable
-    !object.dissubscribable
+    object.all_subscribable?
   end
 
   def moved_to_account

--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -83,7 +83,6 @@ class ActivityPub::ProcessAccountService < BaseService
     @account.suspension_origin = :local if auto_suspend?
     @account.silenced_at       = domain_block.created_at if auto_silence?
     @account.searchability     = :direct   # not null
-    @account.dissubscribable   = false     # not null
 
     set_immediate_protocol_attributes!
 
@@ -125,8 +124,8 @@ class ActivityPub::ProcessAccountService < BaseService
     @account.discoverable            = @json['discoverable'] || false
     @account.indexable               = @json['indexable'] || false
     @account.searchability           = searchability_from_audience
-    @account.dissubscribable         = !subscribable(@account.note)
     @account.settings                = other_settings
+    @account.master_settings         = master_settings(@account.note)
     @account.memorial                = @json['memorial'] || false
   end
 
@@ -320,12 +319,22 @@ class ActivityPub::ProcessAccountService < BaseService
     @subscribable_by = as_array(@json['subscribableBy']).map { |x| value_or_id(x) }
   end
 
-  def subscribable(note)
+  def subscribtion_policy(note)
     if subscribable_by.nil?
-      note.exclude?('[subscribable:no]')
+      note.include?('[subscribable:no]') ? :block : :allow
+    elsif subscribable_by.any? { |uri| ActivityPub::TagManager.instance.public_collection?(uri) }
+      :allow
+    elsif subscribable_by.include?(@account.followers_url)
+      :followers_only
     else
-      subscribable_by.any? { |uri| ActivityPub::TagManager.instance.public_collection?(uri) }
+      :block
     end
+  end
+
+  def master_settings(note)
+    {
+      'subscribtion_policy' => subscribtion_policy(note),
+    }
   end
 
   def other_settings

--- a/app/services/fan_out_on_write_service.rb
+++ b/app/services/fan_out_on_write_service.rb
@@ -53,12 +53,12 @@ class FanOutOnWriteService < BaseService
     when :public, :unlisted, :public_unlisted, :login, :private
       deliver_to_all_followers!
       deliver_to_lists!
-      deliver_to_antennas! if !@account.dissubscribable || (@status.dtl? && DTL_ENABLED && @account.user&.setting_dtl_force_subscribable && @status.tags.exists?(name: DTL_TAG))
+      deliver_to_antennas!
       deliver_to_stl_antennas! if Setting.enable_local_timeline
       deliver_to_ltl_antennas! if Setting.enable_local_timeline
     when :limited
       deliver_to_lists_mentioned_accounts_only!
-      deliver_to_antennas! unless @account.dissubscribable
+      deliver_to_antennas!
       deliver_to_stl_antennas! if Setting.enable_local_timeline
       deliver_to_mentioned_followers!
     else

--- a/db/migrate/20231105225839_add_master_settings_to_accounts.rb
+++ b/db/migrate/20231105225839_add_master_settings_to_accounts.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require Rails.root.join('lib', 'mastodon', 'migration_helpers')
+
+class AddMasterSettingsToAccounts < ActiveRecord::Migration[7.1]
+  include Mastodon::MigrationHelpers
+
+  disable_ddl_transaction!
+
+  class Account < ApplicationRecord; end
+
+  def up
+    safety_assured do
+      add_column :accounts, :master_settings, :jsonb
+
+      Account.transaction do
+        Account.where(dissubscribable: false).update_all(master_settings: { subscribtion_policy: 'allow' }) # rubocop:disable Rails/SkipsModelValidations
+        Account.where(dissubscribable: true).update_all(master_settings: { subscribtion_policy: 'block' })  # rubocop:disable Rails/SkipsModelValidations
+      end
+
+      remove_column :accounts, :dissubscribable
+    end
+  end
+
+  def down
+    safety_assured do
+      add_column_with_default :accounts, :dissubscribable, :boolean, default: false, allow_null: false
+
+      Account.transaction do
+        Account.find_in_batches do |accounts|
+          accounts.each do |account|
+            account.update(dissubscribable: account.master_settings.present? && account.master_settings.subscribtion_policy != 'allow')
+          end
+        end
+      end
+
+      remove_column :accounts, :master_settings
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_10_28_005948) do
+ActiveRecord::Schema[7.1].define(version: 2023_11_05_225839) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -200,9 +200,9 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_28_005948) do
     t.datetime "requested_review_at", precision: nil
     t.boolean "group_allow_private_message"
     t.integer "searchability", default: 2, null: false
-    t.boolean "dissubscribable", default: false, null: false
     t.jsonb "settings"
     t.boolean "indexable", default: false, null: false
+    t.jsonb "master_settings"
     t.index "(((setweight(to_tsvector('simple'::regconfig, (display_name)::text), 'A'::\"char\") || setweight(to_tsvector('simple'::regconfig, (username)::text), 'B'::\"char\")) || setweight(to_tsvector('simple'::regconfig, (COALESCE(domain, ''::character varying))::text), 'C'::\"char\")))", name: "search_index", using: :gin
     t.index "lower((username)::text), COALESCE(lower((domain)::text), ''::text)", name: "index_accounts_on_username_and_domain_lower", unique: true
     t.index ["domain", "id"], name: "index_accounts_on_domain_and_id"

--- a/spec/lib/status_reach_finder_spec.rb
+++ b/spec/lib/status_reach_finder_spec.rb
@@ -381,7 +381,7 @@ describe StatusReachFinder do
       let(:dissubscribable) { false }
       let(:spoiler_text) { '' }
       let(:status) { Fabricate(:status, account: alice, visibility: visibility, searchability: searchability, spoiler_text: spoiler_text) }
-      let(:alice) { Fabricate(:account, username: 'alice', dissubscribable: dissubscribable) }
+      let(:alice) { Fabricate(:account, username: 'alice', master_settings: { subscribtion_policy: dissubscribable ? 'block' : 'allow' }) }
       let(:bob) { Fabricate(:account, username: 'bob', domain: 'example.com', protocol: :activitypub, uri: 'https://example.com/', inbox_url: 'https://example.com/inbox') }
       let(:tom) { Fabricate(:account, username: 'tom', domain: 'tom.com', protocol: :activitypub, uri: 'https://tom.com/', inbox_url: 'https://tom.com/inbox') }
 

--- a/spec/services/fan_out_on_write_service_spec.rb
+++ b/spec/services/fan_out_on_write_service_spec.rb
@@ -10,10 +10,10 @@ RSpec.describe FanOutOnWriteService, type: :service do
   let(:last_active_at) { Time.now.utc }
   let(:visibility) { 'public' }
   let(:searchability) { 'public' }
-  let(:dissubscribable) { false }
+  let(:subscribtion_policy) { :allow }
   let(:status) { Fabricate(:status, account: alice, visibility: visibility, searchability: searchability, text: 'Hello @bob #hoge') }
 
-  let!(:alice) { Fabricate(:user, current_sign_in_at: last_active_at, account_attributes: { dissubscribable: dissubscribable }).account }
+  let!(:alice) { Fabricate(:user, current_sign_in_at: last_active_at, account_attributes: { master_settings: { subscribtion_policy: subscribtion_policy } }).account }
   let!(:bob)   { Fabricate(:user, current_sign_in_at: last_active_at, account_attributes: { username: 'bob' }).account }
   let!(:tom)   { Fabricate(:user, current_sign_in_at: last_active_at).account }
   let!(:ohagi) { Fabricate(:user, current_sign_in_at: last_active_at).account }
@@ -123,11 +123,28 @@ RSpec.describe FanOutOnWriteService, type: :service do
         expect(antenna_feed_of(empty_antenna)).to_not include status.id
       end
 
-      context 'when dissubscribable is true' do
-        let(:dissubscribable) { true }
+      context 'when subscribtion is blocked' do
+        let(:subscribtion_policy) { :block }
 
         it 'is not added to the antenna feed' do
           expect(antenna_feed_of(antenna)).to_not include status.id
+        end
+      end
+
+      context 'when subscribtion is allowed followers only' do
+        let(:subscribtion_policy) { :followers_only }
+        let!(:antenna) { antenna_with_account(ohagi, alice) }
+
+        it 'is not added to the antenna feed' do
+          expect(antenna_feed_of(antenna)).to_not include status.id
+        end
+
+        context 'with following' do
+          let!(:antenna) { antenna_with_account(bob, alice) }
+
+          it 'is added to the antenna feed' do
+            expect(antenna_feed_of(antenna)).to include status.id
+          end
         end
       end
     end
@@ -141,8 +158,8 @@ RSpec.describe FanOutOnWriteService, type: :service do
         expect(antenna_feed_of(empty_antenna)).to_not include status.id
       end
 
-      context 'when dissubscribable is true' do
-        let(:dissubscribable) { true }
+      context 'when subscribtion is blocked' do
+        let(:subscribtion_policy) { :block }
 
         it 'is added to the antenna feed' do
           expect(antenna_feed_of(antenna)).to include status.id
@@ -168,8 +185,8 @@ RSpec.describe FanOutOnWriteService, type: :service do
         expect(antenna_feed_of(empty_antenna)).to_not include status.id
       end
 
-      context 'when dissubscribable is true' do
-        let(:dissubscribable) { true }
+      context 'when subscribtion is blocked' do
+        let(:subscribtion_policy) { :block }
 
         it 'is added to the antenna feed' do
           expect(antenna_feed_of(antenna)).to include status.id
@@ -370,8 +387,8 @@ RSpec.describe FanOutOnWriteService, type: :service do
         expect(antenna_feed_of(empty_antenna)).to_not include status.id
       end
 
-      context 'when dissubscribable is true' do
-        let(:dissubscribable) { true }
+      context 'when subscribtion is blocked' do
+        let(:subscribtion_policy) { :block }
 
         it 'is not added to the antenna feed' do
           expect(antenna_feed_of(antenna)).to_not include status.id
@@ -388,8 +405,8 @@ RSpec.describe FanOutOnWriteService, type: :service do
         expect(antenna_feed_of(empty_antenna)).to_not include status.id
       end
 
-      context 'when dissubscribable is true' do
-        let(:dissubscribable) { true }
+      context 'when subscribtion is blocked' do
+        let(:subscribtion_policy) { :block }
 
         it 'is added to the antenna feed' do
           expect(antenna_feed_of(antenna)).to include status.id
@@ -415,8 +432,8 @@ RSpec.describe FanOutOnWriteService, type: :service do
         expect(antenna_feed_of(empty_antenna)).to_not include status.id
       end
 
-      context 'when dissubscribable is true' do
-        let(:dissubscribable) { true }
+      context 'when subscribtion is blocked' do
+        let(:subscribtion_policy) { :block }
 
         it 'is added to the antenna feed' do
           expect(antenna_feed_of(antenna)).to include status.id


### PR DESCRIPTION
Closes #87 

- [x] データベースマイグレーション
- [ ] データベースマイグレーションの動作確認
- [x] `dissubscribable`を使用している箇所をすべて置き換え
- [x] 既存のテスト習性
- [ ] DTLのアンテナテスト追加
- [x] `followers_only`の場合のアンテナテスト追加
- [ ] `Actor`の`subscribable_by`から購読許可を取得するテスト
- [ ] `Actor`の`summary`から購読許可を取得するテスト
- [ ] 設定画面作成