### PR TITLE
Fix: #236 ログインしていない状態で投稿詳細画面でスタンプを押そうとすると画面が操作不能になる

### DIFF
--- a/app/javascript/mastodon/features/status/index.jsx
+++ b/app/javascript/mastodon/features/status/index.jsx
@@ -285,10 +285,13 @@ class Status extends ImmutablePureComponent {
     if (signedIn) {
       dispatch(emojiReact(status, emoji));
     } else {
-      dispatch(openModal('INTERACTION', {
-        type: 'favourite',
-        accountId: status.getIn(['account', 'id']),
-        url: status.get('url'),
+      dispatch(openModal({
+        modalType: 'INTERACTION',
+        modalProps: {
+          type: 'favourite',
+          accountId: status.getIn(['account', 'id']),
+          url: status.get('uri'),
+        },
       }));
     }
   };


### PR DESCRIPTION
Closes #236 