### PR TITLE
Fix: #205 投稿の編集履歴一覧ポップアップが表示できない

### DIFF
--- a/app/javascript/mastodon/components/dropdown_menu.jsx
+++ b/app/javascript/mastodon/components/dropdown_menu.jsx
@@ -257,7 +257,7 @@ class Dropdown extends PureComponent {
   };
 
   findTarget = () => {
-    return this.target?.buttonRef?.current;
+    return this.target?.buttonRef?.current || this.target;  // kmyblue fixed
   };
 
   componentWillUnmount = () => {


### PR DESCRIPTION
Closes #205 