### PR TITLE
Change: サークルの送り先アカウント指定方法を`account_username`（Fedibirdと同様）に変更

### DIFF
--- a/app/lib/activitypub/tag_manager.rb
+++ b/app/lib/activitypub/tag_manager.rb
@@ -119,10 +119,7 @@ class ActivityPub::TagManager
         end.compact
       end
     when 'limited'
-      status.mentions.each_with_object([]) do |mention, result|
-        result << uri_for(mention.account)
-        result << followers_uri_for(mention.account) if mention.account.group?
-      end.compact
+      []
     end
   end
 

--- a/app/lib/activitypub/tag_manager.rb
+++ b/app/lib/activitypub/tag_manager.rb
@@ -119,7 +119,7 @@ class ActivityPub::TagManager
         end.compact
       end
     when 'limited'
-      []
+      ['kmyblue:Limited'] # to avoid Fedibird personal visibility
     end
   end
 

--- a/app/lib/status_reach_finder.rb
+++ b/app/lib/status_reach_finder.rb
@@ -25,6 +25,12 @@ class StatusReachFinder
     (reached_account_inboxes_for_friend + followers_inboxes_for_friend + friend_inboxes).uniq
   end
 
+  def inboxes_for_limited
+    DeliveryFailureTracker.without_unavailable(
+      @status.mentioned_accounts.where.not(domain: nil).pluck(:inbox_url).compact.uniq
+    )
+  end
+
   def all_inboxes
     (inboxes + inboxes_for_misskey + inboxes_for_friend).uniq
   end


### PR DESCRIPTION
- [x] テストコード
- [x] テストサーバー上で確認