### PR TITLE
Fix: 環境変数でスタンプの最大数を指定した場合、スタンプつけるときにエラーになる問題

### DIFF
--- a/app/models/emoji_reaction.rb
+++ b/app/models/emoji_reaction.rb
@@ -18,7 +18,7 @@ class EmojiReaction < ApplicationRecord
   include Paginable
 
   EMOJI_REACTION_LIMIT = 32_767
-  EMOJI_REACTION_PER_ACCOUNT_LIMIT = ENV.fetch('EMOJI_REACTION_PER_ACCOUNT_LIMIT', 3)
+  EMOJI_REACTION_PER_ACCOUNT_LIMIT = ENV.fetch('EMOJI_REACTION_PER_ACCOUNT_LIMIT', 3).to_i
 
   update_index('statuses', :status)
 


### PR DESCRIPTION
Closes #288 

PRには含まれないが以下のコードでもテスト済

```ruby
EMOJI_REACTION_PER_ACCOUNT_LIMIT = ENV.fetch('EMOJI_REACTION_PER_ACCOUNT_LIMIT', '3').to_i
```