### PR TITLE
Fix rubocop:disable Style/OptionalBooleanParameter

### DIFF
--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -37,12 +37,12 @@ class FeedManager
   # @param [Status] status
   # @param [Account|List] receiver
   # @return [Boolean]
-  def filter?(timeline_type, status, receiver, stl_home = false) # rubocop:disable Style/OptionalBooleanParameter
+  def filter?(timeline_type, status, receiver, stl_home: false)
     case timeline_type
     when :home
       filter_from_home?(status, receiver.id, build_crutches(receiver.id, [status]), :home)
     when :list
-      filter_from_list?(status, receiver) || filter_from_home?(status, receiver.account_id, build_crutches(receiver.account_id, [status]), :list, stl_home)
+      filter_from_list?(status, receiver) || filter_from_home?(status, receiver.account_id, build_crutches(receiver.account_id, [status]), :list, stl_home: stl_home)
     when :mentions
       filter_from_mentions?(status, receiver.id)
     when :tags
@@ -409,7 +409,7 @@ class FeedManager
   # @param [Integer] receiver_id
   # @param [Hash] crutches
   # @return [Boolean]
-  def filter_from_home?(status, receiver_id, crutches, timeline_type = :home, stl_home = false) # rubocop:disable Style/OptionalBooleanParameter
+  def filter_from_home?(status, receiver_id, crutches, timeline_type = :home, stl_home: false)
     return false if receiver_id == status.account_id
     return true  if status.reply? && (status.in_reply_to_id.nil? || status.in_reply_to_account_id.nil?)
     return true if (timeline_type != :list || stl_home) && (crutches[:exclusive_list_users][status.account_id].present? || crutches[:exclusive_antenna_users][status.account_id].present?)

--- a/app/lib/status_cache_hydrator.rb
+++ b/app/lib/status_cache_hydrator.rb
@@ -80,7 +80,7 @@ class StatusCacheHydrator
 
   def mapped_applied_custom_filter(account_id, status)
     CustomFilter
-      .apply_cached_filters(CustomFilter.cached_filters_for(account_id), status, following?(account_id))
+      .apply_cached_filters(CustomFilter.cached_filters_for(account_id), status, following: following?(account_id))
       .map { |filter| serialized_filter(filter) }
   end
 

--- a/app/models/concerns/account_interactions.rb
+++ b/app/models/concerns/account_interactions.rb
@@ -247,7 +247,7 @@ module AccountInteractions
     status.proper.favourites.where(account: self).exists?
   end
 
-  def emoji_reacted?(status, shortcode = nil, domain = nil, domain_force = false) # rubocop:disable Style/OptionalBooleanParameter
+  def emoji_reacted?(status, shortcode = nil, domain = nil, domain_force: false)
     if shortcode.present?
       if domain.present? || domain_force
         status.proper.emoji_reactions.joins(:custom_emoji).where(account: self, name: shortcode, custom_emoji: { domain: domain }).exists?
@@ -277,7 +277,7 @@ module AccountInteractions
 
   def status_matches_filters(status)
     active_filters = CustomFilter.cached_filters_for(id)
-    CustomFilter.apply_cached_filters(active_filters, status, following?(status.account))
+    CustomFilter.apply_cached_filters(active_filters, status, following: following?(status.account))
   end
 
   def followers_for_local_distribution

--- a/app/models/custom_filter.rb
+++ b/app/models/custom_filter.rb
@@ -97,7 +97,7 @@ class CustomFilter < ApplicationRecord
     active_filters.select { |custom_filter, _| !custom_filter.expired? }
   end
 
-  def self.apply_cached_filters(cached_filters, status, following = false) # rubocop:disable Style/OptionalBooleanParameter
+  def self.apply_cached_filters(cached_filters, status, following: false)
     cached_filters.filter_map do |filter, rules|
       next if filter.exclude_follows && following
       next if filter.exclude_localusers && status.account.local?

--- a/app/presenters/status_relationships_presenter.rb
+++ b/app/presenters/status_relationships_presenter.rb
@@ -45,7 +45,7 @@ class StatusRelationshipsPresenter
     active_filters = CustomFilter.cached_filters_for(current_account_id)
 
     @filters_map = statuses.each_with_object({}) do |status, h|
-      filter_matches = CustomFilter.apply_cached_filters(active_filters, status, following?(status.account_id))
+      filter_matches = CustomFilter.apply_cached_filters(active_filters, status, following: following?(status.account_id))
 
       unless filter_matches.empty?
         h[status.id] = filter_matches

--- a/app/services/delivery_antenna_service.rb
+++ b/app/services/delivery_antenna_service.rb
@@ -56,7 +56,7 @@ class DeliveryAntennaService
     antennas = antennas.where(ignore_reblog: false) if @status.reblog?
     antennas = antennas.where(stl: false, ltl: false)
 
-    collection = AntennaCollection.new(@status, @update, false)
+    collection = AntennaCollection.new(@status, @update)
     content = extract_status_plain_text_with_spoiler_text(@status)
 
     antennas.in_batches do |ans|
@@ -89,7 +89,7 @@ class DeliveryAntennaService
     antennas = antennas.where(account: @account.followers).or(antennas.where(account: @account)).where('insert_feeds IS FALSE OR list_id > 0') if home_post && !@status.limited_visibility?
     antennas = antennas.where(account: @status.mentioned_accounts).or(antennas.where(account: @account)).where('insert_feeds IS FALSE OR list_id > 0') if @status.limited_visibility?
 
-    collection = AntennaCollection.new(@status, @update, home_post)
+    collection = AntennaCollection.new(@status, @update, stl_home: home_post)
 
     antennas.in_batches do |ans|
       ans.each do |antenna|
@@ -111,7 +111,7 @@ class DeliveryAntennaService
     antennas = Antenna.available_ltls
     antennas = antennas.where(account_id: Account.without_suspended.joins(:user).select('accounts.id').where('users.current_sign_in_at > ?', User::ACTIVE_DURATION.ago))
 
-    collection = AntennaCollection.new(@status, @update, false)
+    collection = AntennaCollection.new(@status, @update)
 
     antennas.in_batches do |ans|
       ans.each do |antenna|
@@ -140,7 +140,7 @@ class DeliveryAntennaService
   end
 
   class AntennaCollection
-    def initialize(status, update, stl_home = false) # rubocop:disable Style/OptionalBooleanParameter
+    def initialize(status, update, stl_home: false)
       @status = status
       @update = update
       @stl_home = stl_home

--- a/app/workers/feed_insert_worker.rb
+++ b/app/workers/feed_insert_worker.rb
@@ -50,7 +50,7 @@ class FeedInsertWorker
     when :tags
       FeedManager.instance.filter?(:tags, @status, @follower)
     when :list
-      FeedManager.instance.filter?(:list, @status, @list, stl_home?)
+      FeedManager.instance.filter?(:list, @status, @list, stl_home: stl_home?)
     end
   end
 


### PR DESCRIPTION
Fix #304 

#304 の解消対応となります。

対応としては [RuboCopのガイドにある例](https://docs.rubocop.org/rubocop/cops_style.html#styleoptionalbooleanparameter) を元にオプション引数でbooleanを指定していた部分をキーワード引数に置き換えています。
