### PR TITLE
Fix: #397 管理者やユーザーがスタンプ機能を無効にしているときに、投稿のボタン群を以前通り均等幅で詰めるようにする

### DIFF
--- a/app/javascript/mastodon/components/status_action_bar.jsx
+++ b/app/javascript/mastodon/components/status_action_bar.jsx
@@ -472,9 +472,9 @@ class StatusActionBar extends ImmutablePureComponent {
       <EmojiPickerDropdown onPickEmoji={this.handleEmojiPick} button={(
         <IconButton className='status__action-bar__button' title={intl.formatMessage(messages.emojiReaction)} icon='smile-o' iconComponent={EmojiReactionIcon} onClick={this.handleEmojiPickInnerButton} />
       )} />
-    )) || (
+    )) || (enableEmojiReaction && (
       <div className='status__action-bar__button__blank' />
-    );
+    )) || null;
 
     const isReply = status.get('in_reply_to_account_id') === status.getIn(['account', 'id']);
 

--- a/app/javascript/mastodon/features/status/components/action_bar.jsx
+++ b/app/javascript/mastodon/features/status/components/action_bar.jsx
@@ -382,9 +382,9 @@ class ActionBar extends PureComponent {
           <IconButton title={intl.formatMessage(messages.pickEmoji)} icon='smile-o' iconComponent={EmojiReactionIcon} onClick={this.handleEmojiPickInnerButton} />
         )} />
       </div>
-    )) || (
+    )) || (enableEmojiReaction && (
       <div className='detailed-status__button__blank' />
-    );
+    )) || null;
 
     return (
       <div className='detailed-status__action-bar'>


### PR DESCRIPTION
Closes #397 