### PR TITLE
Fix: #416 フィルターでhalf_warnを指定した時の代替値指定ミス

### DIFF
--- a/app/serializers/rest/filter_serializer.rb
+++ b/app/serializers/rest/filter_serializer.rb
@@ -14,7 +14,7 @@ class REST::FilterSerializer < ActiveModel::Serializer
   end
 
   def filter_action
-    return :hide if object.half_warn_action?
+    return :warn if object.half_warn_action?
 
     object.filter_action
   end

--- a/streaming/index.js
+++ b/streaming/index.js
@@ -837,7 +837,7 @@ const startServer = async () => {
                     // representing a value in an enum defined by Ruby on Rails:
                     //
                     // enum { warn: 0, hide: 1, half_warn: 2 }
-                    filter_action: ['warn', 'hide', 'half_warn'][Math.min(filter.filter_action, 1)],
+                    filter_action: filter.filter_action === 2 ? 'warn' : ['warn', 'hide', 'half_warn'][filter.filter_action],
                     filter_action_ex: ['warn', 'hide', 'half_warn'][filter.filter_action],
                     with_quote: filter.with_quote,
                     excludeFollows: filter.exclude_follows,


### PR DESCRIPTION
Closes #416 