### PR TITLE
Fix: #419 フルダークテーマでのplaceholderテキストを薄くする

### DIFF
--- a/app/javascript/styles/full-dark/diff.scss
+++ b/app/javascript/styles/full-dark/diff.scss
@@ -11,7 +11,7 @@ textarea {
   }
 
   &::placeholder {
-    color: lighten($dark-text-color, 36%) !important;
+    color: $dark-text-color !important;
   }
 }
 


### PR DESCRIPTION
Closes #419 