### PR TITLE
Remove: #429 ドメインブロックの「未ログインユーザーに非公開にする」オプション

### DIFF
--- a/app/controllers/admin/domain_blocks_controller.rb
+++ b/app/controllers/admin/domain_blocks_controller.rb
@@ -89,17 +89,17 @@ module Admin
 
     def update_params
       params.require(:domain_block).permit(:severity, :reject_media, :reject_favourite, :reject_reply, :reject_reply_exclude_followers, :reject_send_not_public_searchability, :reject_send_public_unlisted, :reject_send_dissubscribable, :reject_send_media, :reject_send_sensitive, :reject_hashtag,
-                                           :reject_straight_follow, :reject_new_follow, :reject_friend, :detect_invalid_subscription, :reject_reports, :private_comment, :public_comment, :obfuscate, :hidden, :hidden_anonymous)
+                                           :reject_straight_follow, :reject_new_follow, :reject_friend, :detect_invalid_subscription, :reject_reports, :private_comment, :public_comment, :obfuscate, :hidden)
     end
 
     def resource_params
       params.require(:domain_block).permit(:domain, :severity, :reject_media, :reject_favourite, :reject_reply, :reject_reply_exclude_followers, :reject_send_not_public_searchability, :reject_send_public_unlisted, :reject_send_dissubscribable, :reject_send_media, :reject_send_sensitive, :reject_hashtag,
-                                           :reject_straight_follow, :reject_new_follow, :reject_friend, :detect_invalid_subscription, :reject_reports, :private_comment, :public_comment, :obfuscate, :hidden, :hidden_anonymous)
+                                           :reject_straight_follow, :reject_new_follow, :reject_friend, :detect_invalid_subscription, :reject_reports, :private_comment, :public_comment, :obfuscate, :hidden)
     end
 
     def form_domain_block_batch_params
       params.require(:form_domain_block_batch).permit(domain_blocks_attributes: [:enabled, :domain, :severity, :reject_media, :reject_favourite, :reject_reply, :reject_reply_exclude_followers, :reject_send_not_public_searchability, :reject_send_public_unlisted, :reject_send_dissubscribable, :reject_send_media,
-                                                                                 :reject_send_sensitive, :reject_hashtag, :reject_straight_follow, :reject_new_follow, :reject_friend, :detect_invalid_subscription, :reject_reports, :private_comment, :public_comment, :obfuscate, :hidden, :hidden_anonymous])
+                                                                                 :reject_send_sensitive, :reject_hashtag, :reject_straight_follow, :reject_new_follow, :reject_friend, :detect_invalid_subscription, :reject_reports, :private_comment, :public_comment, :obfuscate, :hidden])
     end
 
     def action_from_button

--- a/app/controllers/api/v1/instances/domain_blocks_controller.rb
+++ b/app/controllers/api/v1/instances/domain_blocks_controller.rb
@@ -36,7 +36,6 @@ class Api::V1::Instances::DomainBlocksController < Api::V1::Instances::BaseContr
 
   def set_domain_blocks
     @domain_blocks = DomainBlock.with_user_facing_limitations.by_severity
-    @domain_blocks = @domain_blocks.filter { |block| !block.hidden_anonymous } unless user_signed_in?
   end
 
   def show_rationale_in_response?

--- a/app/models/domain_block.rb
+++ b/app/models/domain_block.rb
@@ -44,7 +44,7 @@ class DomainBlock < ApplicationRecord
   delegate :count, to: :accounts, prefix: true
 
   scope :matches_domain, ->(value) { where(arel_table[:domain].matches("%#{value}%")) }
-  scope :with_user_facing_limitations, -> { where(hidden: false) }
+  scope :with_user_facing_limitations, -> { where(hidden: false, hidden_anonymous: false) }
   scope :with_limitations, lambda {
     where(severity: [:silence, :suspend])
       .or(where(reject_media: true))

--- a/app/views/admin/domain_blocks/edit.html.haml
+++ b/app/views/admin/domain_blocks/edit.html.haml
@@ -31,10 +31,7 @@
     = f.input :public_comment, wrapper: :with_label, label: I18n.t('admin.domain_blocks.public_comment'), hint: t('admin.domain_blocks.public_comment_hint'), as: :string
 
   .fields-group
-    = f.input :hidden, as: :boolean, wrapper: :with_label, label: I18n.t('admin.domain_blocks.hidden'), hint: I18n.t('admin.domain_blocks.hidden_hint')
-
-  .fields-group
-    = f.input :hidden_anonymous, kmyblue: true, as: :boolean, wrapper: :with_label, label: I18n.t('admin.domain_blocks.hidden_anonymous'), hint: I18n.t('admin.domain_blocks.hidden_anonymous_hint')
+    = f.input :hidden, as: :boolean, kmyblue: true, wrapper: :with_label, label: I18n.t('admin.domain_blocks.hidden'), hint: I18n.t('admin.domain_blocks.hidden_hint')
 
   .actions
     = f.button :button, t('generic.save_changes'), type: :submit

--- a/app/views/admin/domain_blocks/new.html.haml
+++ b/app/views/admin/domain_blocks/new.html.haml
@@ -31,10 +31,7 @@
     = f.input :public_comment, wrapper: :with_label, label: I18n.t('admin.domain_blocks.public_comment'), hint: t('admin.domain_blocks.public_comment_hint'), as: :string
 
   .fields-group
-    = f.input :hidden, as: :boolean, wrapper: :with_label, label: I18n.t('admin.domain_blocks.hidden'), hint: I18n.t('admin.domain_blocks.hidden_hint')
-
-  .fields-group
-    = f.input :hidden_anonymous, kmyblue: true, as: :boolean, wrapper: :with_label, label: I18n.t('admin.domain_blocks.hidden_anonymous'), hint: I18n.t('admin.domain_blocks.hidden_anonymous_hint')
+    = f.input :hidden, as: :boolean, kmyblue: true, wrapper: :with_label, label: I18n.t('admin.domain_blocks.hidden'), hint: I18n.t('admin.domain_blocks.hidden_hint')
 
   .actions
     = f.button :button, t('.create'), type: :submit

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -415,8 +415,6 @@ ja:
         mastodon_default: 本家Mastodonの設定項目
       hidden: 非公開にする
       hidden_hint: 公開することで当サーバーの安全が脅かされる場合、このドメインブロックを非公開にすることができます。
-      hidden_anonymous: 未ログインユーザーに非公開にする
-      hidden_anonymous_hint: 公開することで当サーバーの安全が脅かされる場合、非ログインユーザーに限りこのドメインブロックを非公開にすることができます。
       import: インポート
       new:
         create: ブロックを作成

--- a/spec/requests/api/v1/instances/domain_blocks_spec.rb
+++ b/spec/requests/api/v1/instances/domain_blocks_spec.rb
@@ -3,6 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe 'Domain Blocks' do
+  let(:user)    { Fabricate(:user) }
+  let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
+  let(:scopes)  { 'read' }
+  let(:headers) { { Authorization: "Bearer #{token.token}" } }
+
   describe 'GET /api/v1/instance/domain_blocks' do
     before do
       Fabricate(:domain_block)
@@ -22,6 +27,26 @@ RSpec.describe 'Domain Blocks' do
           .and(be_an(Array))
           .and(have_attributes(size: 1))
       end
+
+      context 'with hidden domain block' do
+        before { Fabricate(:domain_block, domain: 'hello.com', hidden: true) }
+
+        it 'returns http success and dont include hidden record' do
+          get api_v1_instance_domain_blocks_path
+
+          expect(body_as_json.pluck(:domain)).to_not include('hello.com')
+        end
+      end
+
+      context 'with hidden domain block from anonymous' do
+        before { Fabricate(:domain_block, domain: 'hello.com', hidden_anonymous: true) }
+
+        it 'returns http success and dont include hidden record' do
+          get api_v1_instance_domain_blocks_path
+
+          expect(body_as_json.pluck(:domain)).to_not include('hello.com')
+        end
+      end
     end
 
     context 'with domain blocks set to users' do
@@ -32,6 +57,42 @@ RSpec.describe 'Domain Blocks' do
 
         expect(response)
           .to have_http_status(404)
+      end
+    end
+
+    context 'with domain blocks set to users with access token' do
+      before { Setting.show_domain_blocks = 'users' }
+
+      it 'returns http not found' do
+        get api_v1_instance_domain_blocks_path, headers: headers
+
+        expect(response)
+          .to have_http_status(200)
+
+        expect(body_as_json)
+          .to be_present
+          .and(be_an(Array))
+          .and(have_attributes(size: 1))
+      end
+
+      context 'with hidden domain block' do
+        before { Fabricate(:domain_block, domain: 'hello.com', hidden: true) }
+
+        it 'returns http success and dont include hidden record' do
+          get api_v1_instance_domain_blocks_path, headers: headers
+
+          expect(body_as_json.pluck(:domain)).to_not include('hello.com')
+        end
+      end
+
+      context 'with hidden domain block from anonymous' do
+        before { Fabricate(:domain_block, domain: 'hello.com', hidden_anonymous: true) }
+
+        it 'returns http success and dont include hidden record' do
+          get api_v1_instance_domain_blocks_path, headers: headers
+
+          expect(body_as_json.pluck(:domain)).to_not include('hello.com')
+        end
       end
     end
 


### PR DESCRIPTION
Closes #429 