### PR TITLE
Fix: タイムライン読み込み時のN+1問題

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -185,6 +185,7 @@ class Status < ApplicationRecord
                    :tags,
                    :preloadable_poll,
                    :reference_objects,
+                   :references,
                    :scheduled_expiration_status,
                    preview_cards_status: [:preview_card],
                    account: [:account_stat, user: :role],


### PR DESCRIPTION
参照先投稿の中身を見るフィルターが原因

引用ではない参照の中身を見ないように修正するのは簡単だけれど、今回はできるだけ仕様を変えないようにしました
今後の調査次第では、後日、負荷軽減を目的として「引用ではない参照先投稿も確認する」オプション（デフォルトでOFF）を追加する可能性はあります