### PR TITLE
Test: 本家に戻ってから再びkmyblueを導入したときのテスト

### DIFF
--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -403,8 +403,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - '3.0'
-          - '3.1'
           - '.ruby-version'
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -403,24 +403,26 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
+          - '3.0'
+          - '3.1'
           - '.ruby-version'
-
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/download-artifact@v3
         with:
-          path: './public'
+          path: './'
           name: ${{ github.sha }}
+
+      - name: Expand archived asset artifacts
+        run: |
+          tar xvzf artifacts.tar.gz
 
       - name: Set up Ruby environment
         uses: ./.github/actions/setup-ruby
         with:
           ruby-version: ${{ matrix.ruby-version}}
-          additional-system-dependencies: ffmpeg imagemagick
-
-      - name: Set up Javascript environment
-        uses: ./.github/actions/setup-javascript
+          additional-system-dependencies: ffmpeg imagemagick libpam-dev
 
       - name: Load database schema
         run: './bin/rails db:create db:schema:load db:seed'
@@ -433,9 +435,8 @@ jobs:
 
       - run: bin/rspec
 
-      - name: Archive logs
-        uses: actions/upload-artifact@v3
-        if: failure()
+      - name: Upload coverage reports to Codecov
+        if: matrix.ruby-version == '.ruby-version'
+        uses: codecov/codecov-action@v3
         with:
-          name: back-ret-logs-${{ matrix.ruby-version }}
-          path: log/
+          files: coverage/lcov/mastodon-back-ret.lcov

--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -384,10 +384,20 @@ jobs:
       DB_HOST: localhost
       DB_USER: postgres
       DB_PASS: postgres
-      DISABLE_SIMPLECOV: true
+      DISABLE_SIMPLECOV: ${{ matrix.ruby-version != '.ruby-version' }}
       RAILS_ENV: test
-      BUNDLE_WITH: test
+      ALLOW_NOPAM: true
+      PAM_ENABLED: true
+      PAM_DEFAULT_SERVICE: pam_test
+      PAM_CONTROLLED_SERVICE: pam_test_controlled
+      OIDC_ENABLED: true
+      OIDC_SCOPE: read
+      SAML_ENABLED: true
+      CAS_ENABLED: true
+      BUNDLE_WITH: 'pam_authentication test'
+      GITHUB_RSPEC: ${{ matrix.ruby-version == '.ruby-version' && github.event.pull_request && 'true' }}
       ES_ENABLED: false
+      BACK_UPSTREAM_FORCE: true
 
     strategy:
       fail-fast: false

--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -348,3 +348,84 @@ jobs:
         with:
           name: test-search-screenshots
           path: tmp/screenshots/
+
+  test-back-and-return:
+    name: Back to original and return test
+    runs-on: ubuntu-latest
+
+    needs:
+      - build
+
+    services:
+      postgres:
+        image: postgres:14-alpine
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_USER: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+      redis:
+        image: redis:7-alpine
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
+
+    env:
+      DB_HOST: localhost
+      DB_USER: postgres
+      DB_PASS: postgres
+      DISABLE_SIMPLECOV: true
+      RAILS_ENV: test
+      BUNDLE_WITH: test
+      ES_ENABLED: false
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version:
+          - '.ruby-version'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v3
+        with:
+          path: './public'
+          name: ${{ github.sha }}
+
+      - name: Set up Ruby environment
+        uses: ./.github/actions/setup-ruby
+        with:
+          ruby-version: ${{ matrix.ruby-version}}
+          additional-system-dependencies: ffmpeg imagemagick
+
+      - name: Set up Javascript environment
+        uses: ./.github/actions/setup-javascript
+
+      - name: Load database schema
+        run: './bin/rails db:create db:schema:load db:seed'
+
+      - name: Back to upstream schema
+        run: 'bundle exec rake dangerous:back_upstream'
+
+      - name: Return to kmyblue
+        run: './bin/rails db:migrate'
+
+      - run: bin/rspec
+
+      - name: Archive logs
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: back-ret-logs-${{ matrix.ruby-version }}
+          path: log/

--- a/lib/tasks/dangerous.rake
+++ b/lib/tasks/dangerous.rake
@@ -7,9 +7,11 @@ namespace :dangerous do
 
     prompt = TTY::Prompt.new
 
-    exit(0) unless prompt.yes?('[1/3] Do you really want to go back to the original Mastodon?', default: false)
-    exit(0) unless prompt.yes?('[2/3] All proprietary data of kmyblue will be deleted and cannot be restored. Are you sure?', default: false)
-    exit(0) unless prompt.yes?('[3/3] This operation is irreversible. You have backups in case this operation causes a system malfunction, do you not?', default: false)
+    unless ENV['BACK_UPSTREAM_FORCE']
+      exit(0) unless prompt.yes?('[1/3] Do you really want to go back to the original Mastodon?', default: false)
+      exit(0) unless prompt.yes?('[2/3] All proprietary data of kmyblue will be deleted and cannot be restored. Are you sure?', default: false)
+      exit(0) unless prompt.yes?('[3/3] This operation is irreversible. You have backups in case this operation causes a system malfunction, do you not?', default: false)
+    end
 
     target_migrations = %w(
       20231022074913


### PR DESCRIPTION
#469 の修正
一度本家に戻してから再びkmyblueにしたときの動作テスト

- `main`ブランチを参照しない
- 以下の場合にテストで落ちる
  - `dangerous.rake`の書き方に問題がある場合、`dangerous:back_upstream`で落ちる
  - `dangerous.rake`で消し忘れたテーブル・カラムがある場合、`db:migrate`で落ちる。マイグレーション履歴の場合、`db:migrate`または`rspec`で落ちる
  - `dangerous.rake`で消しすぎてしまったテーブル・カラムがある場合、`rspec`で落ちる。マイグレーション履歴の場合、`db:migrate`または`rspec`で落ちる

ただし「本家のマイグレーションをkmyblueのものだと勘違いしてまるごと消してしまった場合」のカバーの一部は、このテストではできません。それこそ本家に戻る時に`db:migrate`を念入りにやってもらうしか無いと思います

他にも、kmyblue用のデータを本家で読み取れる形式へ戻し忘れた場合など、このテストも他のテストと同様、完璧に信頼できるとは限りませんので信じすぎには注意です