### PR TITLE
Remove: 現在使われていないドメインブロック無視設定のデッドコード

### DIFF
--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -83,9 +83,7 @@ class StatusesController < ApplicationController
     info = InstanceInfo.find_by(domain: signed_request_account.domain)
     return false if info.nil?
 
-    @misskey_software = %w(misskey calckey cherrypick sharkey).include?(info.software) &&
-                        ((@status.public_unlisted_visibility? && @status.account.user&.setting_reject_public_unlisted_subscription) ||
-                         (@status.unlisted_visibility? && @status.account.user&.setting_reject_unlisted_subscription))
+    @misskey_software = %w(misskey calckey cherrypick sharkey).include?(info.software) && @status.sending_maybe_compromised_privacy?
   end
 
   def status_activity_serializer

--- a/app/lib/activitypub/tag_manager.rb
+++ b/app/lib/activitypub/tag_manager.rb
@@ -153,7 +153,7 @@ class ActivityPub::TagManager
   end
 
   def cc_for_misskey(status)
-    if (status.account.user&.setting_reject_unlisted_subscription && status.unlisted_visibility?) || (status.account.user&.setting_reject_public_unlisted_subscription && status.public_unlisted_visibility?)
+    if status.sending_maybe_compromised_privacy?
       cc = cc_private_visibility(status)
       cc << uri_for(status.reblog.account) if status.reblog?
       return cc

--- a/app/lib/status_reach_finder.rb
+++ b/app/lib/status_reach_finder.rb
@@ -192,13 +192,9 @@ class StatusReachFinder
   end
 
   def banned_domains_of_status(status)
-    if status.account.user&.setting_send_without_domain_blocks
-      []
-    else
-      blocks = DomainBlock.where(domain: nil)
-      blocks = blocks.or(DomainBlock.where(reject_send_sensitive: true)) if (status.with_media? && status.sensitive) || status.spoiler_text?
-      blocks.pluck(:domain).uniq
-    end
+    blocks = DomainBlock.where(domain: nil)
+    blocks = blocks.or(DomainBlock.where(reject_send_sensitive: true)) if (status.with_media? && status.sensitive) || status.spoiler_text?
+    blocks.pluck(:domain).uniq
   end
 
   def banned_domains_for_misskey

--- a/app/lib/status_reach_finder.rb
+++ b/app/lib/status_reach_finder.rb
@@ -200,7 +200,7 @@ class StatusReachFinder
   def banned_domains_for_misskey
     return @banned_domains_for_misskey if defined?(@banned_domains_for_misskey)
 
-    return @banned_domains_for_misskey = [] if (!@status.account.user&.setting_reject_public_unlisted_subscription && !@status.account.user&.setting_reject_unlisted_subscription) || (!@status.public_unlisted_visibility? && !@status.unlisted_visibility?)
+    return @banned_domains_for_misskey = [] unless @status.sending_maybe_compromised_privacy? || (@status.reblog? && @status.reblog.sending_maybe_compromised_privacy?)
 
     domains = banned_domains_for_misskey_of_status(@status)
     domains += banned_domains_for_misskey_of_status(@status.reblog) if @status.reblog? && @status.reblog.local?
@@ -209,7 +209,6 @@ class StatusReachFinder
 
   def banned_domains_for_misskey_of_status(status)
     return [] if status.public_searchability?
-    return [] unless (status.public_unlisted_visibility? && status.account.user&.setting_reject_public_unlisted_subscription) || (status.unlisted_visibility? && status.account.user&.setting_reject_unlisted_subscription)
 
     from_info = InstanceInfo.where(software: %w(misskey calckey cherrypick sharkey)).pluck(:domain)
     from_domain_block = DomainBlock.where(detect_invalid_subscription: true).pluck(:domain)

--- a/app/models/concerns/status/domain_block_concern.rb
+++ b/app/models/concerns/status/domain_block_concern.rb
@@ -12,7 +12,7 @@ module Status::DomainBlockConcern
   def sending_maybe_compromised_privacy?
     return false unless local?
 
-    (public_unlisted_visibility? && public_searchability? && account.user&.setting_reject_public_unlisted_subscription) ||
-      (unlisted_visibility? && public_searchability? && account.user&.setting_reject_unlisted_subscription)
+    (public_unlisted_visibility? && !public_searchability? && account.user&.setting_reject_public_unlisted_subscription) ||
+      (unlisted_visibility? && !public_searchability? && account.user&.setting_reject_unlisted_subscription)
   end
 end

--- a/app/models/concerns/status/domain_block_concern.rb
+++ b/app/models/concerns/status/domain_block_concern.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Status::DomainBlockConcern
+  extend ActiveSupport::Concern
+
+  def sending_sensitive?
+    return false unless local?
+
+    (with_media? && sensitive) || spoiler_text?
+  end
+
+  def sending_maybe_compromised_privacy?
+    return false unless local?
+
+    (public_unlisted_visibility? && public_searchability? && account.user&.setting_reject_public_unlisted_subscription) ||
+      (unlisted_visibility? && public_searchability? && account.user&.setting_reject_unlisted_subscription)
+  end
+end

--- a/app/models/concerns/user/has_settings.rb
+++ b/app/models/concerns/user/has_settings.rb
@@ -71,10 +71,6 @@ module User::HasSettings
     settings['reject_unlisted_subscription']
   end
 
-  def setting_send_without_domain_blocks
-    settings['send_without_domain_blocks']
-  end
-
   def setting_stop_emoji_reaction_streaming
     settings['stop_emoji_reaction_streaming']
   end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -40,6 +40,7 @@ class Status < ApplicationRecord
   include Discard::Model
   include Paginable
   include RateLimitable
+  include Status::DomainBlockConcern
   include Status::SafeReblogInsert
   include Status::SearchConcern
   include Status::SnapshotConcern

--- a/app/models/user_settings.rb
+++ b/app/models/user_settings.rb
@@ -30,7 +30,6 @@ class UserSettings
   setting :public_post_to_unlisted, default: false
   setting :reject_public_unlisted_subscription, default: false
   setting :reject_unlisted_subscription, default: false
-  setting :send_without_domain_blocks, default: false
   setting :reaction_deck, default: nil
   setting :stop_emoji_reaction_streaming, default: false
   setting :emoji_reaction_streaming_notify_impl2, default: false

--- a/app/policies/status_policy.rb
+++ b/app/policies/status_policy.rb
@@ -143,9 +143,8 @@ class StatusPolicy < ApplicationPolicy
   def server_blocking_domain_of_status?(status)
     @domain_block ||= DomainBlock.find_by(domain: current_account&.domain)
     if @domain_block
-      (@domain_block.detect_invalid_subscription && status.public_unlisted_visibility? && status.account.user&.setting_reject_public_unlisted_subscription) ||
-        (@domain_block.detect_invalid_subscription && status.public_visibility? && status.account.user&.setting_reject_unlisted_subscription) ||
-        (@domain_block.reject_send_sensitive && ((status.with_media? && status.sensitive) || status.spoiler_text?))
+      (@domain_block.detect_invalid_subscription && status.sending_maybe_compromised_privacy?) ||
+        (@domain_block.reject_send_sensitive && status.sending_sensitive?)
     else
       false
     end

--- a/app/policies/status_policy.rb
+++ b/app/policies/status_policy.rb
@@ -143,14 +143,9 @@ class StatusPolicy < ApplicationPolicy
   def server_blocking_domain_of_status?(status)
     @domain_block ||= DomainBlock.find_by(domain: current_account&.domain)
     if @domain_block
-      if status.account.user&.setting_send_without_domain_blocks
-        (@domain_block.detect_invalid_subscription && status.public_unlisted_visibility? && status.account.user&.setting_reject_public_unlisted_subscription) ||
-          (@domain_block.detect_invalid_subscription && status.public_visibility? && status.account.user&.setting_reject_unlisted_subscription)
-      else
-        (@domain_block.detect_invalid_subscription && status.public_unlisted_visibility? && status.account.user&.setting_reject_public_unlisted_subscription) ||
-          (@domain_block.detect_invalid_subscription && status.public_visibility? && status.account.user&.setting_reject_unlisted_subscription) ||
-          (@domain_block.reject_send_sensitive && ((status.with_media? && status.sensitive) || status.spoiler_text?))
-      end
+      (@domain_block.detect_invalid_subscription && status.public_unlisted_visibility? && status.account.user&.setting_reject_public_unlisted_subscription) ||
+        (@domain_block.detect_invalid_subscription && status.public_visibility? && status.account.user&.setting_reject_unlisted_subscription) ||
+        (@domain_block.reject_send_sensitive && ((status.with_media? && status.sensitive) || status.spoiler_text?))
     else
       false
     end

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -283,7 +283,6 @@ en:
         setting_reduce_motion: Reduce motion in animations
         setting_reject_public_unlisted_subscription: Reject sending public unlisted visibility/non-public searchability posts to Misskey, Calckey
         setting_reject_unlisted_subscription: Reject sending unlisted visibility/non-public searchability posts to Misskey, Calckey
-        setting_send_without_domain_blocks: Send your post to all server with administrator set as rejecting-post-server for protect you [DEPRECATED]
         setting_show_application: Disclose application used to send posts
         setting_show_emoji_reaction_on_timeline: Show all stamps on timeline
         setting_show_quote_in_home: Show quotes in home, list or antenna timelines

--- a/config/locales/simple_form.ja.yml
+++ b/config/locales/simple_form.ja.yml
@@ -60,7 +60,6 @@ ja:
         person: これは人が使用している通常のアカウントです
         phrase: 投稿内容の大文字小文字や閲覧注意に関係なく一致
         scopes: アプリの API に許可するアクセス権を選択してください。最上位のスコープを選択する場合、個々のスコープを選択する必要はありません。
-        setting_send_without_domain_blocks: 管理人が同人コンテンツの配送にふさわしくないと判断したサーバーに、制限に関係なく全ての投稿を配送します。ただし何が起きても自己責任になります
         setting_aggregate_reblogs: 最近ブーストされた投稿が新たにブーストされても表示しません (設定後受信したものにのみ影響)
         setting_always_send_emails: 通常、Mastodon からメール通知は行われません。
         setting_bookmark_category_needed: すべてのカテゴリから削除したとき、ブックマークが自動で外れるようになります
@@ -294,7 +293,6 @@ ja:
         setting_reduce_motion: アニメーションの動きを減らす
         setting_reject_public_unlisted_subscription: Misskey系サーバーに「ローカル公開」かつ検索許可「誰でも以外」の投稿を「フォロワーのみ」に変換して配送する
         setting_reject_unlisted_subscription: Misskey系サーバーに「非収載」かつ検索許可「誰でも以外」の投稿を「フォロワーのみ」に変換して配送する
-        setting_send_without_domain_blocks: 管理人の設定した配送停止設定を拒否する (非推奨)
         setting_show_application: 送信したアプリを開示する
         setting_show_emoji_reaction_on_timeline: タイムライン上に他の人のつけたスタンプを表示する
         setting_simple_timeline_menu: タイムライン上でメニューの項目を減らす

--- a/spec/lib/activitypub/tag_manager_spec.rb
+++ b/spec/lib/activitypub/tag_manager_spec.rb
@@ -158,18 +158,23 @@ RSpec.describe ActivityPub::TagManager do
     end
 
     it 'returns public collection for public status' do
-      status = Fabricate(:status, visibility: :public)
+      status = Fabricate(:status, account: user.account, visibility: :public)
       expect(subject.cc_for_misskey(status)).to eq [account_followers_url(status.account)]
     end
 
     it 'returns empty array for public_unlisted status' do
-      status = Fabricate(:status, account: user.account, visibility: :public_unlisted)
+      status = Fabricate(:status, account: user.account, visibility: :public_unlisted, searchability: :private)
       expect(subject.cc_for_misskey(status)).to eq []
     end
 
     it 'returns empty array for unlisted status' do
-      status = Fabricate(:status, account: user.account, visibility: :unlisted)
+      status = Fabricate(:status, account: user.account, visibility: :unlisted, searchability: :private)
       expect(subject.cc_for_misskey(status)).to eq []
+    end
+
+    it 'returns public collection for unlisted status but public searchability' do
+      status = Fabricate(:status, account: user.account, visibility: :unlisted, searchability: :public)
+      expect(subject.cc_for_misskey(status)).to eq ['https://www.w3.org/ns/activitystreams#Public']
     end
   end
 

--- a/spec/serializers/activitypub/note_for_misskey_serializer_spec.rb
+++ b/spec/serializers/activitypub/note_for_misskey_serializer_spec.rb
@@ -8,7 +8,7 @@ describe ActivityPub::NoteForMisskeySerializer do
   let(:serialization) { ActiveModelSerializers::SerializableResource.new(parent, serializer: described_class, adapter: ActivityPub::Adapter) }
   let!(:account) { Fabricate(:account) }
   let!(:other) { Fabricate(:account) }
-  let!(:parent) { Fabricate(:status, account: account, visibility: :unlisted) }
+  let!(:parent) { Fabricate(:status, account: account, visibility: :unlisted, searchability: :private) }
   let!(:reply_by_account_first) { Fabricate(:status, account: account, thread: parent, visibility: :public) }
   let!(:reply_by_account_next) { Fabricate(:status, account: account, thread: parent, visibility: :public) }
   let!(:reply_by_other_first) { Fabricate(:status, account: other, thread: parent, visibility: :public) }


### PR DESCRIPTION
テストサーバーで確認

- 「ローカル公開」検索許可「誰でも以外」
  - [x] MastodonでフェッチしてからMisskeyでフェッチ
  - [x] Misskeyへの投稿配送
- 「ローカル公開」検索許可「誰でも」
  - [x] MastodonでフェッチしてからMisskeyでフェッチ
  - [x] Misskeyへの投稿配送
- 「非収載」検索許可「誰でも以外」
  - [x] MastodonでフェッチしてからMisskeyでフェッチ
  - [x] Misskeyへの投稿配送
- 「非収載」検索許可「誰でも」
  - [x] MastodonでフェッチしてからMisskeyでフェッチ
  - [x] Misskeyへの投稿配送
