### PR TITLE
Fix: ドメインブロックがOutboxにおいて動作しない問題

### DIFF
--- a/app/lib/account_statuses_filter.rb
+++ b/app/lib/account_statuses_filter.rb
@@ -33,7 +33,8 @@ class AccountStatusesFilter
     available_visibilities -= [:unlisted] if (domain_block&.detect_invalid_subscription || misskey_software?) && @account.user&.setting_reject_unlisted_subscription
     available_visibilities -= [:login] if current_account.nil?
 
-    scope.merge!(scope.where(spoiler_text: ['', nil])) if domain_block&.reject_send_sensitive
+    scope.merge!(scope.where(sensitive: false)) if domain_block&.reject_send_sensitive
+
     scope.merge!(scope.where(searchability: available_searchabilities))
     scope.merge!(scope.where(visibility: available_visibilities))
 
@@ -153,9 +154,9 @@ class AccountStatusesFilter
   end
 
   def domain_block
-    return nil if @account.nil? || @account.local?
+    return nil if @current_account.nil? || @current_account.local?
 
-    @domain_block = DomainBlock.find_by(domain: @account.domain)
+    @domain_block = DomainBlock.find_by(domain: @current_account.domain)
   end
 
   def misskey_software?

--- a/spec/lib/account_statuses_filter_spec.rb
+++ b/spec/lib/account_statuses_filter_spec.rb
@@ -267,6 +267,80 @@ RSpec.describe AccountStatusesFilter do
       it_behaves_like 'filter params'
     end
 
+    context 'when accessed by a remote account' do
+      let(:current_account) { Fabricate(:account, uri: 'https://example.com/', domain: 'example.com') }
+      let!(:sensitive_status_with_cw) { Fabricate(:status, account: account, visibility: :public, spoiler_text: 'CW', sensitive: true) }
+      let!(:sensitive_status_with_media) do
+        Fabricate(:status, account: account, visibility: :public, sensitive: true).tap do |status|
+          Fabricate(:media_attachment, account: account, status: status)
+        end
+      end
+
+      shared_examples 'as_like_public_visibility' do
+        it 'returns private statuses, replies, and reblogs' do
+          expect(results_unique_visibilities).to match_array %w(login unlisted public_unlisted public)
+
+          expect(results_in_reply_to_ids).to_not be_empty
+
+          expect(results_reblog_of_ids).to_not be_empty
+        end
+
+        context 'when there is a direct status mentioning the non-follower' do
+          let!(:direct_status) { status_with_mention!(:direct, current_account) }
+
+          it 'returns the direct status' do
+            expect(results_ids).to include(direct_status.id)
+          end
+        end
+
+        context 'when there is a direct status mentioning other user' do
+          let!(:direct_status) { status_with_mention!(:direct) }
+
+          it 'not returns the direct status' do
+            expect(results_ids).to_not include(direct_status.id)
+          end
+        end
+
+        context 'when there is a limited status mentioning the non-follower' do
+          let!(:limited_status) { status_with_mention!(:limited, current_account) }
+
+          it 'returns the limited status' do
+            expect(results_ids).to include(limited_status.id)
+          end
+        end
+
+        context 'when there is a limited status mentioning other user' do
+          let!(:limited_status) { status_with_mention!(:limited) }
+
+          it 'not returns the limited status' do
+            expect(results_ids).to_not include(limited_status.id)
+          end
+        end
+      end
+
+      it_behaves_like 'as_like_public_visibility'
+      it_behaves_like 'filter params'
+
+      it 'returns the sensitive status' do
+        expect(results_ids).to include(sensitive_status_with_cw.id)
+        expect(results_ids).to include(sensitive_status_with_media.id)
+      end
+
+      context 'when domain-blocked reject_media' do
+        before do
+          Fabricate(:domain_block, domain: 'example.com', severity: :noop, reject_send_sensitive: true)
+        end
+
+        it_behaves_like 'as_like_public_visibility'
+        it_behaves_like 'filter params'
+
+        it 'does not return the sensitive status' do
+          expect(results_ids).to_not include(sensitive_status_with_cw.id)
+          expect(results_ids).to_not include(sensitive_status_with_media.id)
+        end
+      end
+    end
+
     private
 
     def results_unique_visibilities


### PR DESCRIPTION
Clsoes #373 

ドメインブロック対象に投稿を配送しないオプションを有効にしていても、対象がoutboxへフェッチした場合は対象投稿を返してしまう
これはセキュリティインシデントにすべきか悩んだが、outboxには認証なしでアクセスできるという迂回手段がもともと存在するため今回は扱わないこととした