### PR TITLE
Change: #375 投稿を編集して拡張ドメインブロックの条件にひっかかる状態になった場合、対象サーバーには投稿削除のActivityを送信する

### DIFF
--- a/app/models/concerns/status/domain_block_concern.rb
+++ b/app/models/concerns/status/domain_block_concern.rb
@@ -6,7 +6,7 @@ module Status::DomainBlockConcern
   def sending_sensitive?
     return false unless local?
 
-    (with_media? && sensitive) || spoiler_text?
+    sensitive
   end
 
   def sending_maybe_compromised_privacy?

--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -68,11 +68,7 @@ class PostStatusService < BaseService
   private
 
   def preprocess_attributes!
-    @sensitive    = (if @options[:sensitive].nil?
-                       @media.any? ? @account.user&.setting_default_sensitive : false
-                     else
-                       @options[:sensitive]
-                     end) || @options[:spoiler_text].present?
+    @sensitive    = (@options[:sensitive].nil? ? @account.user&.setting_default_sensitive : @options[:sensitive]) || @options[:spoiler_text].present?
     @text         = @options.delete(:spoiler_text) if @text.blank? && @options[:spoiler_text].present?
     @visibility   = @options[:visibility]&.to_sym || @account.user&.setting_default_privacy&.to_sym
     @visibility   = :limited if %w(mutual circle reply).include?(@options[:visibility])

--- a/spec/lib/status_reach_finder_spec.rb
+++ b/spec/lib/status_reach_finder_spec.rb
@@ -379,15 +379,15 @@ describe StatusReachFinder do
       let(:visibility) { :public }
       let(:searchability) { :public }
       let(:dissubscribable) { false }
-      let(:spoiler_text) { '' }
-      let(:status) { Fabricate(:status, account: alice, visibility: visibility, searchability: searchability, spoiler_text: spoiler_text) }
+      let(:sensitive) { false }
+      let(:status) { Fabricate(:status, account: alice, visibility: visibility, searchability: searchability, sensitive: sensitive) }
       let(:alice) { Fabricate(:account, username: 'alice', master_settings: { subscription_policy: dissubscribable ? 'block' : 'allow' }) }
       let(:bob) { Fabricate(:account, username: 'bob', domain: 'example.com', protocol: :activitypub, uri: 'https://example.com/', inbox_url: 'https://example.com/inbox') }
       let(:tom) { Fabricate(:account, username: 'tom', domain: 'tom.com', protocol: :activitypub, uri: 'https://tom.com/', inbox_url: 'https://tom.com/inbox') }
 
       context 'when reject_send_sensitive' do
         let(:properties) { { reject_send_sensitive: true } }
-        let(:spoiler_text) { 'CW' }
+        let(:sensitive) { true }
 
         it 'does not include the inbox of blocked domain' do
           expect(subject.inboxes).to_not include 'https://example.com/inbox'


### PR DESCRIPTION
Closes #375 

- テスト
  - [x] 対象外サーバーへ編集を送信（センシティブフラグ＝以下フラグ変更なし）
  - [x] 対象外サーバーへ編集を送信（フラグ変更あり）
  - [x] 対象外サーバーへ編集を送信（フラグOFFで投稿→フラグON→フラグOFF→フラグOFF→フラグON）
  - [x] 対象外サーバーへ編集を送信（フラグONで投稿→フラグOFF→フラグOFF→フラグON）
  - [x] 対象サーバーへ編集を送信（フラグ変更なし）
  - [x] 対象サーバーへ編集を送信（フラグ変更あり）
  - [x] 対象サーバーへ編集を送信（フラグOFFで投稿→フラグON→フラグOFF→フラグOFF→フラグON）
  - [x] 対象サーバーへ編集を送信（フラグONで投稿→フラグOFF→フラグOFF→フラグON）