### PR TITLE
Add: Misskeyに相互限定投稿を配送しないオプション

### DIFF
--- a/app/models/concerns/user/has_settings.rb
+++ b/app/models/concerns/user/has_settings.rb
@@ -123,6 +123,10 @@ module User::HasSettings
     settings['allow_quote']
   end
 
+  def setting_reject_send_limited_to_suspects
+    settings['reject_send_limited_to_suspects']
+  end
+
   def setting_noindex
     settings['noindex']
   end

--- a/app/models/user_settings.rb
+++ b/app/models/user_settings.rb
@@ -41,6 +41,7 @@ class UserSettings
   setting :dtl_force_subscribable, default: false
   setting :lock_follow_from_bot, default: false
   setting :allow_quote, default: true
+  setting :reject_send_limited_to_suspects, default: false
 
   setting_inverse_alias :indexable, :noindex
 

--- a/app/services/process_mentions_service.rb
+++ b/app/services/process_mentions_service.rb
@@ -105,7 +105,10 @@ class ProcessMentionsService < BaseService
   def process_mutual!
     mentioned_account_ids = @current_mentions.map(&:account_id)
 
-    @status.account.mutuals.reorder(nil).find_each do |target_account|
+    mutuals = @status.account.mutuals
+    mutuals = mutuals.where.not(domain: InstanceInfo.where(software: 'misskey').select(:domain)).or(mutuals.where(domain: nil)) if @status.account.user&.setting_reject_send_limited_to_suspects
+
+    mutuals.reorder(nil).find_each do |target_account|
       @current_mentions << @status.mentions.new(silent: true, account: target_account) unless mentioned_account_ids.include?(target_account.id)
     end
   end

--- a/app/views/settings/privacy_extra/show.html.haml
+++ b/app/views/settings/privacy_extra/show.html.haml
@@ -45,5 +45,8 @@
     .fields-group
       = ff.input :reject_unlisted_subscription, kmyblue: true, as: :boolean, wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_reject_unlisted_subscription'), hint: I18n.t('simple_form.hints.defaults.setting_reject_unlisted_subscription')
 
+    .fields-group
+      = ff.input :reject_send_limited_to_suspects, kmyblue: true, as: :boolean, wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_reject_send_limited_to_suspects'), hint: I18n.t('simple_form.hints.defaults.setting_reject_send_limited_to_suspects')
+
   .actions
     = f.button :button, t('generic.save_changes'), type: :submit

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -283,6 +283,7 @@ en:
         setting_public_post_to_unlisted: Convert public post to public unlisted if not using Web app
         setting_reduce_motion: Reduce motion in animations
         setting_reject_public_unlisted_subscription: Reject sending public unlisted visibility/non-public searchability posts to Misskey, Calckey
+        setting_reject_send_limited_to_suspects: Reject sending mutual posts to Misskey
         setting_reject_unlisted_subscription: Reject sending unlisted visibility/non-public searchability posts to Misskey, Calckey
         setting_reverse_search_quote: Perform word-by-word search when search keywords are not enclosed in double quotes
         setting_show_application: Disclose application used to send posts

--- a/config/locales/simple_form.ja.yml
+++ b/config/locales/simple_form.ja.yml
@@ -79,6 +79,7 @@ ja:
         setting_enable_emoji_reaction: この機能を無効にしても、他の人はあなたの投稿に絵文字をつけられます
         setting_hide_network: フォローとフォロワーの情報がプロフィールページで見られないようにします
         setting_public_post_to_unlisted: 未対応のサードパーティアプリからもローカル公開で投稿できますが、公開投稿はWeb以外できなくなります
+        setting_reject_send_limited_to_suspects: これは「相互のみ」投稿に適用されます。サークル投稿は例外なく配送されます。一部のMisskeyサーバーが独自に限定投稿へ対応しましたが、相互のみ投稿を行うたびに相手に通知されるなど複数の問題があるため、気になる人向けの設定です
         setting_reject_unlisted_subscription: Misskeyやそのフォークは、フォローしていないアカウントの「非収載」投稿を **購読・検索** することができます。これはkmyblueの挙動と異なります。そのようなサーバーに、指定した公開範囲の投稿を「フォロワーのみ」として配送します。ただし構造上、完璧な対応は困難でたまに非収載として配信されること、ご理解ください
         setting_reverse_search_quote: 検索ワードをダブルクオートで囲って検索した場合、表記ゆれ多めの検索結果になります。Mastodon標準とは逆の挙動となります。
         setting_show_application: 投稿するのに使用したアプリが投稿の詳細ビューに表示されるようになります
@@ -293,6 +294,7 @@ ja:
         setting_public_post_to_unlisted: サードパーティから公開範囲「公開」で投稿した場合、「ローカル公開」に変更する
         setting_reduce_motion: アニメーションの動きを減らす
         setting_reject_public_unlisted_subscription: Misskey系サーバーに「ローカル公開」かつ検索許可「誰でも以外」の投稿を「フォロワーのみ」に変換して配送する
+        setting_reject_send_limited_to_suspects: Misskey系サーバーに「相互のみ」投稿を配送しない
         setting_reject_unlisted_subscription: Misskey系サーバーに「非収載」かつ検索許可「誰でも以外」の投稿を「フォロワーのみ」に変換して配送する
         setting_reverse_search_quote: ダブルクオートで囲まず検索した時、単語単位で検索する
         setting_show_application: 送信したアプリを開示する


### PR DESCRIPTION
ちょっと我ながらこのオプションを作るのは気持ち悪いのですけども、ioがきちんと対応するまでつけます

現在、misskey.ioにおける限定投稿受信に問題点は３つあります。

https://kmy.blue/@software/111764768883753787
https://kmy.blue/@software/111810490533506890

ただ１つ目の問題に比べたら２／３つ目は些少なものです。１つ目の問題点は、限定投稿をするたびに相手に通知がいくことです。

サークル投稿であればmisskey.ioのユーザーをサークルに登録しないことで回避可能ですが、相互限定投稿はどうにもなりませんのでこれを避けるためのオプションが必要です。