### PR TITLE
Change: #457 サイレンスされているユーザーに、フォロー相手以外への絵文字リアクションを禁止

### DIFF
--- a/app/lib/activitypub/activity/like.rb
+++ b/app/lib/activitypub/activity/like.rb
@@ -34,7 +34,7 @@ class ActivityPub::Activity::Like < ActivityPub::Activity
 
   def process_emoji_reaction
     return if !@original_status.account.local? && !Setting.receive_other_servers_emoji_reaction
-    return if silence_domain? && (!@original_status.local? || !@original_status.account.following?(@account))
+    return if (silence_domain? || @account.silenced?) && (!@original_status.local? || !@original_status.account.following?(@account))
 
     # custom emoji
     emoji = nil

--- a/app/services/emoji_react_service.rb
+++ b/app/services/emoji_react_service.rb
@@ -16,6 +16,8 @@ class EmojiReactService < BaseService
     authorize_with account, status, :emoji_reaction?
     @status = status
 
+    raise Mastodon::ValidationError, I18n.t('reactions.errors.banned') if account.silenced? && !status.account.following?(account)
+
     with_redis_lock("emoji_reaction:#{status.id}") do
       shortcode, domain = name.split('@')
       domain = nil if TagManager.instance.local_domain?(domain)

--- a/spec/services/emoji_react_service_spec.rb
+++ b/spec/services/emoji_react_service_spec.rb
@@ -52,6 +52,29 @@ RSpec.describe EmojiReactService, type: :service do
     end
   end
 
+  context 'when user is silenced' do
+    before do
+      sender.silence!
+    end
+
+    it 'emoji reaction is not allowed' do
+      expect { subject }.to raise_error Mastodon::ValidationError
+    end
+  end
+
+  context 'when user is silenced but following target' do
+    before do
+      author.follow!(sender)
+      sender.silence!
+    end
+
+    it 'emoji reaction is allowed' do
+      expect(subject.count).to eq 1
+      expect(subject.first.name).to eq '😀'
+      expect(subject.first.custom_emoji_id).to be_nil
+    end
+  end
+
   context 'when over limit' do
     let(:name) { '🚗' }
 


### PR DESCRIPTION
Closes #457 