### PR TITLE
Fix: #502 ユーザー設定のログインユーザーのみ(ja.statuses.visibilities.login)の翻訳がない

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1931,6 +1931,8 @@ en:
     too_many_hashtags: Too many hashtags
     visibilities:
       direct: Direct
+      login: Login only
+      login_long: Only logined users
       private: Followers-only
       private_long: Only show to followers
       public: Public

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1904,6 +1904,8 @@ ja:
     too_many_hashtags: ハッシュタグが多すぎます
     visibilities:
       direct: ダイレクト
+      login: ログインユーザーのみ
+      login_long: ログインしたユーザーのみが見ることができます
       private: フォロワー限定
       private_long: フォロワーにのみ表示されます
       public: 公開


### PR DESCRIPTION
Closes #502 