### PR TITLE
Change: ローカルタイムラインを無効にしている時、`/api/v1/timelines/public`タイムライン取得で「リモートユーザーのみ」指定も無効化

### DIFF
--- a/app/javascript/mastodon/features/firehose/index.jsx
+++ b/app/javascript/mastodon/features/firehose/index.jsx
@@ -171,21 +171,21 @@ const Firehose = ({ feedType, multiColumn }) => {
         <ColumnSettings />
       </ColumnHeader>
 
-      <div className='account__section-headline'>
-        {enableLocalTimeline && (
+      {enableLocalTimeline && (
+        <div className='account__section-headline'>
           <NavLink exact to='/public/local'>
             <FormattedMessage tagName='div' id='firehose.local' defaultMessage='This server' />
           </NavLink>
-        )}
+          
+          <NavLink exact to='/public/remote'>
+            <FormattedMessage tagName='div' id='firehose.remote' defaultMessage='Other servers' />
+          </NavLink>
 
-        <NavLink exact to='/public/remote'>
-          <FormattedMessage tagName='div' id='firehose.remote' defaultMessage='Other servers' />
-        </NavLink>
-
-        <NavLink exact to='/public'>
-          <FormattedMessage tagName='div' id='firehose.all' defaultMessage='All' />
-        </NavLink>
-      </div>
+          <NavLink exact to='/public'>
+            <FormattedMessage tagName='div' id='firehose.all' defaultMessage='All' />
+          </NavLink>
+        </div>
+      )}
 
       <StatusListContainer
         prepend={prependBanner}

--- a/app/models/public_feed.rb
+++ b/app/models/public_feed.rb
@@ -53,7 +53,7 @@ class PublicFeed
   end
 
   def remote_only?
-    options[:remote] && !options[:local]
+    options[:remote] && !options[:local] && Setting.enable_local_timeline
   end
 
   def hide_local_users?

--- a/spec/models/public_feed_spec.rb
+++ b/spec/models/public_feed_spec.rb
@@ -88,8 +88,20 @@ RSpec.describe PublicFeed do
           expect(subject).to include(local_status.id)
         end
 
-        it 'excludes public_unlisted statuses' do
+        it 'includes public_unlisted statuses' do
           expect(subject).to include(public_unlisted_status.id)
+        end
+
+        context 'when local timeline is disabled' do
+          before do
+            Form::AdminSettings.new(enable_local_timeline: '0').save
+          end
+
+          it 'includes statuses' do
+            expect(subject).to include(remote_status.id)
+            expect(subject).to include(local_status.id)
+            expect(subject).to include(public_unlisted_status.id)
+          end
         end
       end
 
@@ -106,6 +118,18 @@ RSpec.describe PublicFeed do
 
         it 'excludes public_unlisted statuses' do
           expect(subject).to include(public_unlisted_status.id)
+        end
+
+        context 'when local timeline is disabled' do
+          before do
+            Form::AdminSettings.new(enable_local_timeline: '0').save
+          end
+
+          it 'includes statuses' do
+            expect(subject).to include(remote_status.id)
+            expect(subject).to include(local_status.id)
+            expect(subject).to include(public_unlisted_status.id)
+          end
         end
       end
     end
@@ -159,15 +183,15 @@ RSpec.describe PublicFeed do
         it 'includes public_unlisted statuses' do
           expect(subject).to include(public_unlisted_status.id)
         end
-      end
 
-      context 'when local timeline is disabled' do
-        before do
-          Form::AdminSettings.new(enable_local_timeline: '0').save
-        end
+        context 'when local timeline is disabled' do
+          before do
+            Form::AdminSettings.new(enable_local_timeline: '0').save
+          end
 
-        it 'does not include all statuses' do
-          expect(subject).to eq []
+          it 'does not include all statuses' do
+            expect(subject).to eq []
+          end
         end
       end
     end
@@ -192,6 +216,18 @@ RSpec.describe PublicFeed do
         it 'excludes public_unlisted statuses' do
           expect(subject).to_not include(public_unlisted_status.id)
         end
+
+        context 'when local timeline is disabled' do
+          before do
+            Form::AdminSettings.new(enable_local_timeline: '0').save
+          end
+
+          it 'includes statuses with local' do
+            expect(subject).to include(remote_status.id)
+            expect(subject).to include(local_status.id)
+            expect(subject).to include(public_unlisted_status.id)
+          end
+        end
       end
 
       context 'with a viewer' do
@@ -204,6 +240,18 @@ RSpec.describe PublicFeed do
 
         it 'excludes public_unlisted statuses' do
           expect(subject).to_not include(public_unlisted_status.id)
+        end
+
+        context 'when local timeline is disabled' do
+          before do
+            Form::AdminSettings.new(enable_local_timeline: '0').save
+          end
+
+          it 'includes statuses with local' do
+            expect(subject).to include(remote_status.id)
+            expect(subject).to include(local_status.id)
+            expect(subject).to include(public_unlisted_status.id)
+          end
         end
       end
     end

--- a/spec/requests/api/v1/timelines/public_spec.rb
+++ b/spec/requests/api/v1/timelines/public_spec.rb
@@ -67,6 +67,7 @@ describe 'Public' do
 
         context 'when local timeline is disabled' do
           let(:ltl_enabled) { false }
+          let(:expected_statuses) { [local_status, remote_status, media_status] }
 
           it_behaves_like 'a successful request to the public timeline'
         end


### PR DESCRIPTION
リアルタイムフィードの「リモートのみ」タブを削除し、リモート＆ローカル全部あわせたタイムラインしか表示できないように
ローカルのことを意識してしまうため必要

ただしAPIとして`remote=1`を指定した場合、「連合タイムライン」を「リモートのみ」有効にして表示してしまうクライアントアプリがあるかもしれないので、空の配列ではなく`remote=1`を無視してローカル投稿も含む配列を返す
（そういうのはクライアントアプリが悪いのだが、混合されうる場合があると思った）