### PR TITLE
Fix: #540 emoji_reactionsテーブルのuriカラムへのインデックス設定時、重複を削除する処理

### DIFF
--- a/db/migrate/20240212230358_fix_uri_index_to_emoji_reactions.rb
+++ b/db/migrate/20240212230358_fix_uri_index_to_emoji_reactions.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-class FixUriIndexToEmojiReactions < ActiveRecord::Migration[7.1]
-  disable_ddl_transaction!
-
-  def change
-    add_index :emoji_reactions, :uri, unique: true, algorithm: :concurrently
-  end
-end

--- a/db/post_migrate/20240212230358_fix_uri_index_to_emoji_reactions.rb
+++ b/db/post_migrate/20240212230358_fix_uri_index_to_emoji_reactions.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class FixUriIndexToEmojiReactions < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  class EmojiReaction < ApplicationRecord
+  end
+
+  def up
+    # Remove duplications (very old kmyblue code [2023/03-04] maybe made some duplications)
+    duplications = EmojiReaction.where('uri IN (SELECT uri FROM emoji_reactions GROUP BY uri HAVING COUNT(*) > 1)')
+                                .to_a.group_by(&:uri).to_h
+
+    if duplications.any?
+      EmojiReaction.transaction do
+        duplications.each do |h|
+          h[1].drop(1).each(&:destroy)
+        end
+      end
+    end
+
+    add_index :emoji_reactions, :uri, unique: true, algorithm: :concurrently
+  end
+
+  def down
+    remove_index :emoji_reactions, :uri
+  end
+end


### PR DESCRIPTION
Closes #540 