### PR TITLE
Fix: #531 投稿フォームの公開範囲の選択肢で、スマホから見ると常に「ログインユーザーのみ」が表示される

### DIFF
--- a/app/javascript/mastodon/features/compose/components/privacy_dropdown.jsx
+++ b/app/javascript/mastodon/features/compose/components/privacy_dropdown.jsx
@@ -271,15 +271,15 @@ class PrivacyDropdown extends PureComponent {
       this.options = this.options.filter((opt) => !['mutual', 'circle'].includes(opt.value));
     }
 
-    this.selectableOptions = [...this.options];
-
     if (!enableLoginPrivacy) {
-      this.selectableOptions = this.selectableOptions.filter((opt) => opt.value !== 'login');
+      this.options = this.options.filter((opt) => opt.value !== 'login');
     }
 
     if (!enableLocalPrivacy) {
-      this.selectableOptions = this.selectableOptions.filter((opt) => opt.value !== 'public_unlisted');
+      this.options = this.options.filter((opt) => opt.value !== 'public_unlisted');
     }
+
+    this.selectableOptions = [...this.options];
   }
 
   setTargetRef = c => {


### PR DESCRIPTION
Closes #531 