### PR TITLE
Add: ホワイトリスト運用時、承認待ちリモートアカウントの概念ならびに操作画面

### DIFF
--- a/app/controllers/admin/accounts_controller.rb
+++ b/app/controllers/admin/accounts_controller.rb
@@ -168,6 +168,12 @@ module Admin
         'approve'
       elsif params[:reject]
         'reject'
+      elsif params[:approve_remote]
+        'approve_remote'
+      elsif params[:approve_remote_domain]
+        'approve_remote_domain'
+      elsif params[:reject_remote]
+        'reject_remote'
       end
     end
   end

--- a/app/helpers/admin/accounts_helper.rb
+++ b/app/helpers/admin/accounts_helper.rb
@@ -7,6 +7,7 @@ module Admin::AccountsHelper
       [t('admin.accounts.moderation.silenced'), 'silenced'],
       [t('admin.accounts.moderation.disabled'), 'disabled'],
       [t('admin.accounts.moderation.suspended'), 'suspended'],
+      [t('admin.accounts.moderation.remote_pending'), 'remote_pending'],
       [safe_join([t('admin.accounts.moderation.pending'), "(#{pending_user_count_label})"], ' '), 'pending'],
     ]
   end

--- a/app/javascript/mastodon/components/visibility_icon.tsx
+++ b/app/javascript/mastodon/components/visibility_icon.tsx
@@ -55,7 +55,7 @@ const messages = defineMessages({
   },
   circle_short: {
     id: 'privacy.circle.short',
-    defaultMessage: 'Circle members only',
+    defaultMessage: 'Circle',
   },
   reply_short: {
     id: 'privacy.reply.short',

--- a/app/models/account_filter.rb
+++ b/app/models/account_filter.rb
@@ -88,6 +88,8 @@ class AccountFilter
       Account.without_suspended
     when 'pending'
       accounts_with_users.merge(User.pending)
+    when 'remote_pending'
+      Account.remote_pending
     when 'suspended'
       Account.suspended
     when 'disabled'

--- a/app/policies/account_policy.rb
+++ b/app/policies/account_policy.rb
@@ -64,4 +64,12 @@ class AccountPolicy < ApplicationPolicy
   def review?
     role.can?(:manage_taxonomies)
   end
+
+  def approve_remote?
+    role.can?(:manage_users) && record.remote_pending
+  end
+
+  def reject_remote?
+    role.can?(:manage_users) && record.remote_pending
+  end
 end

--- a/app/views/admin/accounts/index.html.haml
+++ b/app/views/admin/accounts/index.html.haml
@@ -50,6 +50,13 @@
 
           = f.button safe_join([fa_icon('times'), t('admin.accounts.reject')]), name: :reject, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
 
+        - elsif @accounts.any?(&:remote_pending)
+          = f.button safe_join([fa_icon('check'), t('admin.accounts.approve')]), name: :approve_remote, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
+
+          = f.button safe_join([fa_icon('check'), t('admin.accounts.approve_domain')]), name: :approve_remote_domain, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
+
+          = f.button safe_join([fa_icon('times'), t('admin.accounts.reject')]), name: :reject_remote, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
+
         = f.button safe_join([fa_icon('lock'), t('admin.accounts.perform_full_suspension')]), name: :suspend, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
     - if @accounts.total_count > @accounts.size
       .batch-table__select-all

--- a/app/views/admin/ng_words/show.html.haml
+++ b/app/views/admin/ng_words/show.html.haml
@@ -32,8 +32,12 @@
   .fields-group
     = f.input :hide_local_users_for_anonymous, wrapper: :with_label, as: :boolean, label: t('admin.ng_words.hide_local_users_for_anonymous')
 
+  %p.hint
+    = t 'admin.ng_words.remote_approval_hint'
+    = link_to t('admin.ng_words.remote_approval_list'), admin_accounts_path(status: 'remote_pending', origin: 'remote')
+
   .fields-group
-    = f.input :permit_new_account_domains, wrapper: :with_label, as: :text, kmyblue: true, input_html: { rows: 6 }, label: t('admin.special_instances.permit_new_account_domains'), hint: t('admin.special_instances.permit_new_account_domains_hint')
+    = f.input :permit_new_account_domains, wrapper: :with_label, as: :text, kmyblue: true, input_html: { rows: 6 }, label: t('admin.ng_words.permit_new_account_domains')
 
   .actions
     = f.button :button, t('generic.save_changes'), type: :submit

--- a/app/workers/redownload_avatar_worker.rb
+++ b/app/workers/redownload_avatar_worker.rb
@@ -10,7 +10,7 @@ class RedownloadAvatarWorker
   def perform(id)
     account = Account.find(id)
 
-    return if account.suspended? || DomainBlock.rule_for(account.domain)&.reject_media?
+    return if (account.suspended? && !account.remote_pending) || DomainBlock.rule_for(account.domain)&.reject_media?
     return if account.avatar_remote_url.blank? || account.avatar_file_name.present?
 
     account.reset_avatar!

--- a/app/workers/redownload_header_worker.rb
+++ b/app/workers/redownload_header_worker.rb
@@ -10,7 +10,7 @@ class RedownloadHeaderWorker
   def perform(id)
     account = Account.find(id)
 
-    return if account.suspended? || DomainBlock.rule_for(account.domain)&.reject_media?
+    return if (account.suspended? && !account.remote_pending) || DomainBlock.rule_for(account.domain)&.reject_media?
     return if account.header_remote_url.blank? || account.header_file_name.present?
 
     account.reset_header!

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,6 +33,7 @@ en:
     accounts:
       add_email_domain_block: Block e-mail domain
       approve: Approve
+      approve_domain: Approve domain
       approved_msg: Successfully approved %{username}'s sign-up application
       are_you_sure: Are you sure?
       avatar: Avatar
@@ -93,6 +94,7 @@ en:
         all: All
         disabled: Disabled
         pending: Pending
+        remote_pending: Pending (Remote)
         silenced: Limited
         suspended: Suspended
         title: Moderation
@@ -647,9 +649,12 @@ en:
       keywords_for_stranger_mention: Reject keywords when mention/reply/reference/quote from strangers
       keywords_for_stranger_mention_hint: This words are checked posts from other servers only.
       keywords_hint: The first character of the line is "?". to use regular expressions
+      permit_new_account_domains: Domain list to automatically approve new users
       post_hash_tags_max: Hash tags max for posts
       post_mentions_max: Mentions max for posts
       post_stranger_mentions_max: 投稿に設定可能なメンションの最大数 (If the mentions include at least one person who is not a follower of yours)
+      remote_approval_list: List of remote accounts awaiting approval
+      remote_approval_hint: If you set one or more domains on the list of domains for which you want to automatically approve new users, newly recognized accounts on unspecified domains will be placed in suspend status. You can review that list and approve them if necessary. If none is specified, all remote accounts are approved immediately.
       stranger_mention_from_local_ng: フォローしていないアカウントへのメンションのNGワードを、ローカルユーザーによる投稿にも適用する
       stranger_mention_from_local_ng_hint: サーバーの登録が承認制でない場合、あなたのサーバーにもスパムが入り込む可能性があります
       test_error: Testing is returned any errors
@@ -918,8 +923,6 @@ en:
     special_instances:
       emoji_reaction_disallow_domains: Domains we are not permitted emoji reaction
       emoji_reaction_disallow_domains_hint: If you need to be considerate to your coalition partners, set the domain with a new line separator. It is not possible to put an emoji reaction on a post from a set domain.
-      permit_new_account_domains: Domain to allow recognition of new accounts
-      permit_new_account_domains_hint: Only new account information sent from the domain specified here will be saved if more than one is specified,
       title: Special servers
     statuses:
       account: Author

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -232,6 +232,7 @@ en:
         update_user_role: Update Role
       actions:
         approve_appeal_html: "%{name} approved moderation decision appeal from %{target}"
+        approve_remote_account_html: "%{name} approved %{target} join on this server"
         approve_user_html: "%{name} approved sign-up from %{target}"
         assigned_to_self_report_html: "%{name} assigned report %{target} to themselves"
         change_email_user_html: "%{name} changed the e-mail address of user %{target}"
@@ -271,6 +272,7 @@ en:
         memorialize_account_html: "%{name} turned %{target}'s account into a memoriam page"
         promote_user_html: "%{name} promoted user %{target}"
         reject_appeal_html: "%{name} rejected moderation decision appeal from %{target}"
+        reject_remote_account_html: "%{name} rejected %{target} join on this server"
         reject_user_html: "%{name} rejected sign-up from %{target}"
         remove_avatar_user_html: "%{name} removed %{target}'s avatar"
         remove_history_status_html: "%{name} removed post edit histories by %{target}"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -229,6 +229,7 @@ ja:
         update_user_role: ロールを更新
       actions:
         approve_appeal_html: "%{name}さんが%{target}さんからの抗議を承認しました"
+        approve_remote_account_html: "%{name}さんが%{target}さんの参加を承認しました"
         approve_user_html: "%{name}さんが%{target}さんからの登録を承認しました"
         assigned_to_self_report_html: "%{name}さんが通報 %{target}を自身の担当に割り当てました"
         change_email_user_html: "%{name}さんが%{target}さんのメールアドレスを変更しました"
@@ -268,6 +269,7 @@ ja:
         memorialize_account_html: "%{name}さんが%{target}さんを追悼アカウントページに登録しました"
         promote_user_html: "%{name}さんが%{target}さんを昇格しました"
         reject_appeal_html: "%{name}さんが%{target}からの抗議を却下しました"
+        reject_remote_account_html: "%{name}さんが%{target}さんの参加を却下しました"
         reject_user_html: "%{name}さんが%{target}さんからの登録を拒否しました"
         remove_avatar_user_html: "%{name}さんが%{target}さんのアイコンを削除しました"
         remove_history_status_html: "%{name}さんが%{target}さんの投稿の編集履歴を削除しました"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -31,6 +31,7 @@ ja:
     accounts:
       add_email_domain_block: メールドメインブロックに追加
       approve: 承認
+      approve_domain: ドメインを承認
       approved_msg: '%{username}さんの登録申請を承認しました'
       are_you_sure: 本当に実行しますか？
       avatar: アイコン
@@ -91,6 +92,7 @@ ja:
         all: すべて
         disabled: 無効化済み
         pending: 承認待ち
+        remote_pending: 承認待ち (リモート)
         silenced: 制限
         suspended: 停止済み
         title: モデレーション
@@ -640,9 +642,12 @@ ja:
       keywords_for_stranger_mention: フォローしていないアカウントへのメンションや参照で利用できないキーワード
       keywords_for_stranger_mention_hint: フォローしていないアカウントへのメンション、参照、引用にのみ適用されます
       keywords_hint: 行を「?」で始めると、正規表現が使えます
+      permit_new_account_domains: 新規ユーザーを自動承認するドメイン
       post_hash_tags_max: 投稿に設定可能なハッシュタグの最大数
       post_mentions_max: 投稿に設定可能なメンションの最大数
       post_stranger_mentions_max: 投稿に設定可能なメンションの最大数 (メンション先にフォロワー以外を1人でも含む場合)
+      remote_approval_list: 承認待ちのリモートアカウント一覧
+      remote_approval_hint: 新規ユーザーを自動承認するドメインリストに1つ以上のドメインを設定すると、指定されていないドメインで新しく認識されたアカウントはサスペンド状態になります。その一覧を確認し、必要であれば承認を行うことができます。何も指定しなかった場合、全てのリモートアカウントが即座に承認されます。
       stranger_mention_from_local_ng: フォローしていないアカウントへのメンションのNGワードを、ローカルユーザーによる投稿にも適用する
       stranger_mention_from_local_ng_hint: サーバーの登録が承認制でない場合、あなたのサーバーにもスパムが入り込む可能性があります
       test_error: NGワードのテストに失敗しました。正規表現のミスが含まれているかもしれません
@@ -909,8 +914,6 @@ ja:
     special_instances:
       emoji_reaction_disallow_domains: 自分のサーバーが絵文字リアクションをすることを許可しないドメイン
       emoji_reaction_disallow_domains_hint: 連合先に配慮する必要がある場合、ドメインを改行区切りで設定します。設定されたドメインの投稿に絵文字リアクションを付けることはできません。
-      permit_new_account_domains: 新規アカウントの認知を許可するドメイン
-      permit_new_account_domains_hint: 1つ以上指定した場合、ここで指定されたドメインから送られてくる新規アカウント情報だけが保存されるようになります
       title: 特殊なサーバー
     statuses:
       account: 作成者

--- a/db/migrate/20240217093511_add_remote_pending_to_accounts.rb
+++ b/db/migrate/20240217093511_add_remote_pending_to_accounts.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddRemotePendingToAccounts < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_column :accounts, :remote_pending, :boolean, null: false, default: false
+
+    add_index :accounts, :remote_pending, unique: false, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_17_022038) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_17_093511) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -194,10 +194,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_17_022038) do
     t.jsonb "settings"
     t.boolean "indexable", default: false, null: false
     t.jsonb "master_settings"
+    t.boolean "remote_pending", default: false, null: false
     t.index "(((setweight(to_tsvector('simple'::regconfig, (display_name)::text), 'A'::\"char\") || setweight(to_tsvector('simple'::regconfig, (username)::text), 'B'::\"char\")) || setweight(to_tsvector('simple'::regconfig, (COALESCE(domain, ''::character varying))::text), 'C'::\"char\")))", name: "search_index", using: :gin
     t.index "lower((username)::text), COALESCE(lower((domain)::text), ''::text)", name: "index_accounts_on_username_and_domain_lower", unique: true
     t.index ["domain", "id"], name: "index_accounts_on_domain_and_id"
     t.index ["moved_to_account_id"], name: "index_accounts_on_moved_to_account_id", where: "(moved_to_account_id IS NOT NULL)"
+    t.index ["remote_pending"], name: "index_accounts_on_remote_pending"
     t.index ["uri"], name: "index_accounts_on_uri"
     t.index ["url"], name: "index_accounts_on_url", opclass: :text_pattern_ops, where: "(url IS NOT NULL)"
   end

--- a/lib/tasks/dangerous.rake
+++ b/lib/tasks/dangerous.rake
@@ -86,6 +86,7 @@ namespace :dangerous do
       20240212230358
       20240216042730
       20240217022038
+      20240217093511
     )
     # Removed: account_groups
     target_tables = %w(
@@ -112,6 +113,7 @@ namespace :dangerous do
       %w(accounts group_allow_private_message),
       # Removed: accounts group_message_following_only
       %w(accounts master_settings),
+      %w(accounts remote_pending),
       %w(accounts searchability),
       %w(accounts settings),
       # Removed: accounts stop_emoji_reaction_streaming

--- a/spec/services/activitypub/process_account_service_spec.rb
+++ b/spec/services/activitypub/process_account_service_spec.rb
@@ -30,13 +30,17 @@ RSpec.describe ActivityPub::ProcessAccountService, type: :service do
     it 'created account in a simple case' do
       expect(subject).to_not be_nil
       expect(subject.uri).to eq 'https://foo.test'
+      expect(subject.suspended?).to be false
+      expect(subject.remote_pending).to be false
     end
 
     context 'when is blocked' do
       let(:permit_new_account_domains) { ['foo.bar'] }
 
-      it 'does not create account' do
-        expect(subject).to be_nil
+      it 'creates pending account' do
+        expect(subject).to_not be_nil
+        expect(subject.suspended?).to be true
+        expect(subject.remote_pending).to be true
       end
 
       context 'with has existing account' do
@@ -46,7 +50,38 @@ RSpec.describe ActivityPub::ProcessAccountService, type: :service do
 
         it 'updated account' do
           expect(subject).to_not be_nil
+          expect(subject.suspended?).to be false
+          expect(subject.remote_pending).to be false
+          expect(subject.suspension_origin_local?).to be true
           expect(subject.note).to eq 'new bio'
+        end
+      end
+
+      context 'with has existing suspended pending account' do
+        before do
+          Fabricate(:account, uri: 'https://foo.test', domain: 'example.com', username: 'alice', note: 'old bio', suspended_at: 1.day.ago, remote_pending: true, suspension_origin: :local)
+        end
+
+        it 'updated account' do
+          expect(subject).to_not be_nil
+          expect(subject.suspended?).to be true
+          expect(subject.remote_pending).to be true
+          expect(subject.suspension_origin_local?).to be true
+          expect(subject.note).to eq 'new bio'
+        end
+      end
+
+      context 'with has existing suspended account' do
+        before do
+          Fabricate(:account, uri: 'https://foo.test', domain: 'example.com', username: 'alice', note: 'old bio', suspended_at: 1.day.ago, suspension_origin: :local)
+        end
+
+        it 'does not update account' do
+          expect(subject).to_not be_nil
+          expect(subject.suspended?).to be true
+          expect(subject.remote_pending).to be false
+          expect(subject.suspension_origin_local?).to be true
+          expect(subject.note).to eq 'old bio'
         end
       end
     end
@@ -57,6 +92,8 @@ RSpec.describe ActivityPub::ProcessAccountService, type: :service do
       it 'does not create account' do
         expect(subject).to_not be_nil
         expect(subject.uri).to eq 'https://foo.test'
+        expect(subject.suspended?).to be false
+        expect(subject.remote_pending).to be false
       end
     end
   end

--- a/spec/services/activitypub/process_account_service_spec.rb
+++ b/spec/services/activitypub/process_account_service_spec.rb
@@ -52,7 +52,6 @@ RSpec.describe ActivityPub::ProcessAccountService, type: :service do
           expect(subject).to_not be_nil
           expect(subject.suspended?).to be false
           expect(subject.remote_pending).to be false
-          expect(subject.suspension_origin_local?).to be true
           expect(subject.note).to eq 'new bio'
         end
       end


### PR DESCRIPTION
ホワイトリスト作るならこれも作るべきだと思います
新しいアカウントを認識した時、即時削除せず承認待ち状態にします