### PR TITLE
Fix: #596 リモート保留中のアカウントにおいて「活動を完全に停止する」を行ったときも「却下」と同様の動きをするように

### DIFF
--- a/app/models/form/account_batch.rb
+++ b/app/models/form/account_batch.rb
@@ -117,6 +117,8 @@ class Form::AccountBatch
     accounts.find_each do |account|
       if account.user_pending?
         reject_account(account)
+      elsif account.suspended? && account.remote_pending
+        reject_remote_account(account)
       else
         suspend_account(account)
       end


### PR DESCRIPTION
Closes #596 