### PR TITLE
Change: 一般ユーザーはデフォルトで招待を不可にするよう変更

### DIFF
--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -47,6 +47,7 @@ class UserRole < ApplicationRecord
     ALL  = FLAGS.values.reduce(&:|)
 
     DEFAULT = 0
+    EVERYONE_ALLOWED = FLAGS[:invite_users]
 
     CATEGORIES = {
       invites: %i(
@@ -196,6 +197,6 @@ class UserRole < ApplicationRecord
   end
 
   def validate_dangerous_permissions
-    errors.add(:permissions_as_keys, :dangerous) if everyone? && Flags::DEFAULT & permissions != permissions
+    errors.add(:permissions_as_keys, :dangerous) if everyone? && Flags::EVERYONE_ALLOWED & permissions != permissions
   end
 end

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -46,7 +46,7 @@ class UserRole < ApplicationRecord
     NONE = 0
     ALL  = FLAGS.values.reduce(&:|)
 
-    DEFAULT = FLAGS[:invite_users]
+    DEFAULT = 0
 
     CATEGORIES = {
       invites: %i(

--- a/config/roles.yml
+++ b/config/roles.yml
@@ -28,6 +28,7 @@ admin:
     - manage_custom_emojis
     - manage_webhooks
     - manage_roles
+    - invite_users
 owner:
   name: Owner
   position: 1000

--- a/spec/models/user_role_spec.rb
+++ b/spec/models/user_role_spec.rb
@@ -135,11 +135,15 @@ RSpec.describe UserRole do
     end
 
     it 'has default permissions' do
-      expect(subject.permissions).to eq UserRole::FLAGS[:invite_users]
+      expect(subject.permissions).to eq 0
     end
 
     it 'has negative position' do
       expect(subject.position).to eq(-1)
+    end
+
+    it 'is able to add invite permission' do
+      expect { subject.update!(permissions: UserRole::FLAGS[:invite_users]) }.to_not raise_error
     end
   end
 


### PR DESCRIPTION
標準Mastodonでは、新規登録した管理者以外のユーザーには招待権限が与えられます。しかしこれは以下の理由からセキュリティホールになると考えられます。

- 善人のふりをして登録して、一定時間経過後（例えば管理者が任意のタイミングで登録を承認制にした場合）に大量のスパムを招待を用いて登録する
- 新規登録上限、新規登録可能時間帯、その他のkmyblue独自の制限が迂回可能である

したがって、もしMastodonが初期状態で新規登録を制限するならば、招待も同じく制限されるべきと考えます