### PR TITLE
Add: 管理画面で特に負荷の大きい処理を無効にする環境変数

### DIFF
--- a/app/helpers/high_load_helper.rb
+++ b/app/helpers/high_load_helper.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module HighLoadHelper
+  def allow_high_load?
+    ENV.fetch('ALLOW_HIGH_LOAD', 'true') == 'true'
+  end
+  module_function :allow_high_load?
+end

--- a/app/javascript/mastodon/components/admin/Counter.jsx
+++ b/app/javascript/mastodon/components/admin/Counter.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 
-import { FormattedNumber } from 'react-intl';
+import { FormattedNumber, FormattedMessage } from 'react-intl';
 
 import classNames from 'classnames';
 
@@ -43,6 +43,7 @@ export default class Counter extends PureComponent {
   state = {
     loading: true,
     data: null,
+    empty: false,
   };
 
   componentDidMount () {
@@ -52,6 +53,7 @@ export default class Counter extends PureComponent {
       this.setState({
         loading: false,
         data: res.data,
+        empty: res.data.length === 0,
       });
     }).catch(err => {
       console.error(err);
@@ -60,7 +62,7 @@ export default class Counter extends PureComponent {
 
   render () {
     const { label, href, target } = this.props;
-    const { loading, data } = this.state;
+    const { loading, data, empty } = this.state;
 
     let content;
 
@@ -70,6 +72,12 @@ export default class Counter extends PureComponent {
           <span className='sparkline__value__total'><Skeleton width={43} /></span>
           <span className='sparkline__value__change'><Skeleton width={43} /></span>
         </>
+      );
+    } else if (empty) {
+      content = (
+        <span className='sparkline__value__change'>
+          <FormattedMessage id='admin.dimenssions.disabled_key' defaultMessage='This information is invalid.' />
+        </span>
       );
     } else {
       const measure = data[0];
@@ -94,7 +102,7 @@ export default class Counter extends PureComponent {
         </div>
 
         <div className='sparkline__graph'>
-          {!loading && (
+          {!loading && !empty && (
             <Sparklines width={259} height={55} data={data[0].data.map(x => x.value * 1)}>
               <SparklinesCurve />
             </Sparklines>

--- a/app/javascript/mastodon/components/admin/Dimension.jsx
+++ b/app/javascript/mastodon/components/admin/Dimension.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 
-import { FormattedNumber } from 'react-intl';
+import { FormattedNumber, FormattedMessage } from 'react-intl';
 
 import api from 'mastodon/api';
 import { Skeleton } from 'mastodon/components/skeleton';
@@ -21,6 +21,7 @@ export default class Dimension extends PureComponent {
   state = {
     loading: true,
     data: null,
+    empty: false,
   };
 
   componentDidMount () {
@@ -30,6 +31,7 @@ export default class Dimension extends PureComponent {
       this.setState({
         loading: false,
         data: res.data,
+        empty: res.data.length === 0,
       });
     }).catch(err => {
       console.error(err);
@@ -38,7 +40,7 @@ export default class Dimension extends PureComponent {
 
   render () {
     const { label, limit } = this.props;
-    const { loading, data } = this.state;
+    const { loading, data, empty } = this.state;
 
     let content;
 
@@ -57,6 +59,18 @@ export default class Dimension extends PureComponent {
                 </td>
               </tr>
             ))}
+          </tbody>
+        </table>
+      );
+    } else if (empty) {
+      content = (
+        <table>
+          <tbody>
+            <tr className='dimension__item'>
+              <td className='dimension__item__value' colSpan={2}>
+                <FormattedMessage id='admin.dimenssions.disabled_key' defaultMessage='This information is invalid.' />
+              </td>
+            </tr>
           </tbody>
         </table>
       );

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -89,6 +89,7 @@
   "admin.dashboard.retention.average": "Average",
   "admin.dashboard.retention.cohort": "Sign-up month",
   "admin.dashboard.retention.cohort_size": "New users",
+  "admin.dimenssions.disabled_key": "This information is invalid.",
   "admin.impact_report.instance_accounts": "Accounts profiles this would delete",
   "admin.impact_report.instance_followers": "Followers our users would lose",
   "admin.impact_report.instance_follows": "Followers their users would lose",

--- a/app/javascript/mastodon/locales/ja.json
+++ b/app/javascript/mastodon/locales/ja.json
@@ -88,6 +88,7 @@
   "admin.dashboard.retention.average": "平均",
   "admin.dashboard.retention.cohort": "サインアップ月",
   "admin.dashboard.retention.cohort_size": "新しいユーザー",
+  "admin.dimenssions.disabled_key": "この情報は無効です。",
   "admin.impact_report.instance_accounts": "プロフィール情報が削除されるアカウントの数",
   "admin.impact_report.instance_followers": "このサーバーのユーザーが失うフォロワー数",
   "admin.impact_report.instance_follows": "対象のサーバーのユーザーが失うフォロワー数",

--- a/app/lib/admin/metrics/dimension.rb
+++ b/app/lib/admin/metrics/dimension.rb
@@ -14,6 +14,8 @@ class Admin::Metrics::Dimension
   }.freeze
 
   def self.retrieve(dimension_keys, start_at, end_at, limit, params)
+    dimension_keys.delete('servers') unless HighLoadHelper.allow_high_load?
+
     Array(dimension_keys).filter_map do |key|
       klass = DIMENSIONS[key.to_sym]
       klass&.new(start_at, end_at, limit, klass.with_params? ? params.require(key.to_sym) : nil)

--- a/app/lib/admin/metrics/measure.rb
+++ b/app/lib/admin/metrics/measure.rb
@@ -19,6 +19,8 @@ class Admin::Metrics::Measure
   }.freeze
 
   def self.retrieve(measure_keys, start_at, end_at, params)
+    measure_keys.delete('instance_statuses') unless HighLoadHelper.allow_high_load?
+
     Array(measure_keys).filter_map do |key|
       klass = MEASURES[key.to_sym]
       klass&.new(start_at, end_at, klass.with_params? ? params.require(key.to_sym) : nil)


### PR DESCRIPTION
これは本来セキュリティインシデントとして起票したものですが、確かに懸念はあるけど秘密裏にやるほど大それたものではないと感じましたので、通常のPRとして起票します。

```
/api/v1/admin/dimensions?keys=[servers]
```

これは、管理者向けダッシュボードでアクティブなサーバーを返すAPIです。
サーバーkmy.blueの場合、このAPI呼び出しから結果が返ってくるまで３分以上かかります。その間に発行されるSQLは１つだけ。AWSのCloudWatchで見ても、データベースディスクの負荷（IOPS）が３分間常にMAXまで張り付いており、繰り返し呼び出すとサーバーが落ちる可能性が高いと考えざるを得ません。例えば悪意を持った者がモデレーターに任命された場合など、モデレーターが気軽にサーバーを落とす／ありえない負荷をかける手段として有効です。

```
/api/v1/admin/measures?keys=[instance_users]
```

これは、既知のサーバーで特定インスタンスの全投稿数を返すAPIです。
サーバーkmy.blueの場合、それほど負荷ではありませんが、過去には１０以上のインスタンス情報を同時表示しただけでデータベースが落ちたこともあり取り扱いには注意が必要なAPIです。

実際の画面において、これらのAPIは遅延的に処理され、呼び出しが完了しなくても次の操作を行うことが出来ます。なので、その遅延処理が高負荷であることに気づきにくく、サーバーを落としやすい要因といえます。
ただ本家Mastodonでは、kmy.blueより圧倒的に大規模なサーバーが大量にあるにかかわらず今までこの問題に対処されていないということは、この問題はkmyblue独自機能に起因する可能性もあるのではないかと思います。その問題の調査を行う前に、いったん当該APIを無効にできる環境変数を追加します。
この環境変数はデフォルトで`true`で、これは高負荷APIを正常に処理することを意味します。本来はデフォルトで無効にしたいのですが、お一人様サーバーなどでは特にインパクトはないと考えられるのと、本家Mastodonの挙動にあわせたものです。