### PR TITLE
Fix: #655 センシティブフラグ付きの画像を編集するとフラグが外れる

### DIFF
--- a/app/javascript/mastodon/reducers/compose.js
+++ b/app/javascript/mastodon/reducers/compose.js
@@ -629,7 +629,7 @@ export default function compose(state = initialState, action) {
         map.set('spoiler', true);
         map.set('spoiler_text', action.spoiler_text);
       } else {
-        map.set('spoiler', false);
+        map.set('spoiler', action.status.get('sensitive'));
         map.set('spoiler_text', '');
       }
 


### PR DESCRIPTION
Closes #655