### PR TITLE
Change: #671 「メディアを常に閲覧注意としてマークする」をONにしている時、２枚目以降の画像アップロードでセンシティブフラグを付けない

### DIFF
--- a/app/javascript/mastodon/actions/compose.js
+++ b/app/javascript/mastodon/actions/compose.js
@@ -339,7 +339,7 @@ export function uploadCompose(files) {
         if (status === 200) {
           dispatch(uploadComposeSuccess(data, file));
 
-          if (defaultSensitive && !spoiler) {
+          if (defaultSensitive && !spoiler && (media.size + i) === 0) {
             dispatch(changeComposeSpoilerness());
           }
         } else if (status === 202) {


### PR DESCRIPTION
Closes #671 