### PR TITLE
Add: #92 アカウントのおすすめタグを真ん中のカラムからも確認できるように

### DIFF
--- a/app/javascript/mastodon/components/hashtag_bar.tsx
+++ b/app/javascript/mastodon/components/hashtag_bar.tsx
@@ -196,9 +196,14 @@ export function getHashtagBarForStatus(status: StatusLike) {
   };
 }
 
+export function getFeaturedHashtagBar(acct: string, tags: string[]) {
+  return <HashtagBar acct={acct} hashtags={tags} />;
+}
+
 const HashtagBar: React.FC<{
   hashtags: string[];
-}> = ({ hashtags }) => {
+  acct?: string;
+}> = ({ hashtags, acct }) => {
   const [expanded, setExpanded] = useState(false);
   const handleClick = useCallback(() => {
     setExpanded(true);
@@ -215,7 +220,10 @@ const HashtagBar: React.FC<{
   return (
     <div className='hashtag-bar'>
       {revealedHashtags.map((hashtag) => (
-        <Link key={hashtag} to={`/tags/${hashtag}`}>
+        <Link
+          key={hashtag}
+          to={acct ? `/@${acct}/tagged/${hashtag}` : `/tags/${hashtag}`}
+        >
           #<span>{hashtag}</span>
         </Link>
       ))}

--- a/app/javascript/mastodon/components/hashtag_bar.tsx
+++ b/app/javascript/mastodon/components/hashtag_bar.tsx
@@ -197,13 +197,14 @@ export function getHashtagBarForStatus(status: StatusLike) {
 }
 
 export function getFeaturedHashtagBar(acct: string, tags: string[]) {
-  return <HashtagBar acct={acct} hashtags={tags} />;
+  return <HashtagBar acct={acct} hashtags={tags} defaultExpanded />;
 }
 
 const HashtagBar: React.FC<{
   hashtags: string[];
   acct?: string;
-}> = ({ hashtags, acct }) => {
+  defaultExpanded?: boolean;
+}> = ({ hashtags, acct, defaultExpanded }) => {
   const [expanded, setExpanded] = useState(false);
   const handleClick = useCallback(() => {
     setExpanded(true);
@@ -213,9 +214,10 @@ const HashtagBar: React.FC<{
     return null;
   }
 
-  const revealedHashtags = expanded
-    ? hashtags
-    : hashtags.slice(0, VISIBLE_HASHTAGS);
+  const revealedHashtags =
+    expanded || defaultExpanded
+      ? hashtags
+      : hashtags.slice(0, VISIBLE_HASHTAGS);
 
   return (
     <div className='hashtag-bar'>
@@ -228,7 +230,7 @@ const HashtagBar: React.FC<{
         </Link>
       ))}
 
-      {!expanded && hashtags.length > VISIBLE_HASHTAGS && (
+      {!expanded && !defaultExpanded && hashtags.length > VISIBLE_HASHTAGS && (
         <button className='link-button' onClick={handleClick}>
           <FormattedMessage
             id='hashtags.and_other'

--- a/app/javascript/mastodon/features/account_timeline/components/header.jsx
+++ b/app/javascript/mastodon/features/account_timeline/components/header.jsx
@@ -18,6 +18,7 @@ class Header extends ImmutablePureComponent {
 
   static propTypes = {
     account: ImmutablePropTypes.record,
+    featuredTags: PropTypes.array,
     onFollow: PropTypes.func.isRequired,
     onBlock: PropTypes.func.isRequired,
     onMention: PropTypes.func.isRequired,
@@ -123,7 +124,7 @@ class Header extends ImmutablePureComponent {
   };
 
   render () {
-    const { account, hidden, hideTabs } = this.props;
+    const { account, featuredTags, hidden, hideTabs } = this.props;
 
     if (account === null) {
       return null;
@@ -136,6 +137,7 @@ class Header extends ImmutablePureComponent {
 
         <InnerHeader
           account={account}
+          featuredTags={featuredTags}
           onFollow={this.handleFollow}
           onBlock={this.handleBlock}
           onMention={this.handleMention}

--- a/app/javascript/mastodon/features/account_timeline/containers/header_container.jsx
+++ b/app/javascript/mastodon/features/account_timeline/containers/header_container.jsx
@@ -37,6 +37,7 @@ const makeMapStateToProps = () => {
     account: getAccount(state, accountId),
     domain: state.getIn(['meta', 'domain']),
     hidden: getAccountHidden(state, accountId),
+    featuredTags: state.getIn(['user_lists', 'featured_tags', accountId, 'items']),
   });
 
   return mapStateToProps;


### PR DESCRIPTION
Closes #92 

結局、フィールドの上に挿入することにしました

![image](https://github.com/kmycode/mastodon/assets/13672783/0edb0aad-8d3f-464a-bf16-fa104237c5b0)
