### PR TITLE
Fix: #666 絵文字リアクション機能に対応していないと思われるサーバーの投稿を詳細画面で開いた時、「n reactions」の表示を隠す

### DIFF
--- a/app/javascript/mastodon/features/status/components/detailed_status.jsx
+++ b/app/javascript/mastodon/features/status/components/detailed_status.jsx
@@ -222,9 +222,9 @@ class DetailedStatus extends ImmutablePureComponent {
     }
 
     let emojiReactionsBar = null;
+    const emojiReactionAvailableServer = !isHideItem('emoji_reaction_unavailable_server') || status.getIn(['account', 'emoji_reaction_available_server']);
     if (status.get('emoji_reactions')) {
       const emojiReactions = status.get('emoji_reactions');
-      const emojiReactionAvailableServer = !isHideItem('emoji_reaction_unavailable_server') || status.getIn(['account', 'emoji_reaction_available_server']);
       if (emojiReactions.size > 0 && enableEmojiReaction && emojiReactionAvailableServer) {
         emojiReactionsBar = <StatusEmojiReactionsBar emojiReactions={emojiReactions} status={status} onEmojiReact={this.props.onEmojiReact} onUnEmojiReact={this.props.onUnEmojiReact} />;
       }
@@ -279,7 +279,9 @@ class DetailedStatus extends ImmutablePureComponent {
       );
     }
 
-    if (this.props.history) {
+    if (!enableEmojiReaction || !emojiReactionAvailableServer) {
+      emojiReactionsLink = null;
+    } else if (this.props.history) {
       emojiReactionsLink = (
         <Link to={`/@${status.getIn(['account', 'acct'])}/${status.get('id')}/emoji_reactions`} className='detailed-status__link'>
           <span className='detailed-status__favorites'>


### PR DESCRIPTION
Closes #666 