### PR TITLE
Fix: #367 #557 Webで引用された投稿を表示すると、その投稿のリアクション情報がリセットされる

### DIFF
--- a/app/javascript/mastodon/actions/importer/index.js
+++ b/app/javascript/mastodon/actions/importer/index.js
@@ -72,7 +72,7 @@ export function importFetchedStatuses(statuses) {
         processStatus(status.reblog);
       }
 
-      if (status.quote && status.quote.id) {
+      if (status.quote && status.quote.id && !getState().getIn(['statuses', status.id])) {
         processStatus(status.quote);
       }
 


### PR DESCRIPTION
Closes #367
Closes #557 

とりあえずJavaScript部分だけ
将来的に、ブーストと動作を合わせる、APIレベルで調整入れるほうがいいと思う