### PR TITLE
Fix: #703 NGワード、センシティブワード「無関係なフォロワーへのメンション」が、自分自身への参照・引用にも適用される

### DIFF
--- a/app/models/concerns/account/interactions.rb
+++ b/app/models/concerns/account/interactions.rb
@@ -191,6 +191,10 @@ module Account::Interactions
     active_relationships.exists?(target_account: other_account)
   end
 
+  def following_or_self?(other_account)
+    id == other_account.id || following?(other_account)
+  end
+
   def following_anyone?
     active_relationships.exists?
   end

--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -249,12 +249,12 @@ class PostStatusService < BaseService
   def mention_to_stranger?
     return @mention_to_stranger if defined?(@mention_to_stranger)
 
-    @mention_to_stranger = @status.mentions.map(&:account).to_a.any? { |mentioned_account| mentioned_account.id != @account.id && !mentioned_account.following?(@account) } ||
-                           (@in_reply_to && @in_reply_to.account.id != @account.id && !@in_reply_to.account.following?(@account))
+    @mention_to_stranger = @status.mentions.map(&:account).to_a.any? { |mentioned_account| !mentioned_account.following_or_self?(@account) } ||
+                           (@in_reply_to && !@in_reply_to.account.following_or_self?(@account))
   end
 
   def reference_to_stranger?
-    referred_statuses.any? { |status| !status.account.following?(@account) }
+    referred_statuses.any? { |status| !status.account.following_or_self?(@account) }
   end
 
   def referred_statuses

--- a/app/services/update_status_service.rb
+++ b/app/services/update_status_service.rb
@@ -123,12 +123,12 @@ class UpdateStatusService < BaseService
   end
 
   def mention_to_stranger?
-    @status.mentions.map(&:account).to_a.any? { |mentioned_account| mentioned_account.id != @status.account.id && !mentioned_account.following?(@status.account) } ||
-      (@status.thread.present? && @status.thread.account.id != @status.account.id && !@status.thread.account.following?(@status.account))
+    @status.mentions.map(&:account).to_a.any? { |mentioned_account| !mentioned_account.following_or_self?(@status.account) } ||
+      (@status.thread.present? && !@status.thread.account.following_or_self?(@status.account))
   end
 
   def reference_to_stranger?
-    referred_statuses.any? { |status| !status.account.following?(@status.account) }
+    referred_statuses.any? { |status| !status.account.following_or_self?(@status.account) }
   end
 
   def referred_statuses


### PR DESCRIPTION
Closes #703