### PR TITLE
Fix: [WebUI] フルダークテーマの修正

### DIFF
--- a/app/javascript/styles/full-dark/diff.scss
+++ b/app/javascript/styles/full-dark/diff.scss
@@ -1,6 +1,7 @@
 input[type='text']:not(#cw-spoiler-input),
 input[type='search'],
 input[type='number'],
+textarea#upload-modal__description, 
 input:not([type]) {
   background: $ui-base-color !important;
   color: $primary-text-color !important;

--- a/app/javascript/styles/full-dark/diff.scss
+++ b/app/javascript/styles/full-dark/diff.scss
@@ -25,6 +25,7 @@ input:not([type]) {
   color: $classic-secondary-color !important;
 }
 
+.compose-form__warning,
 .modal-root__modal {
   background: lighten($classic-base-color, 12%);
 }

--- a/app/javascript/styles/full-dark/diff.scss
+++ b/app/javascript/styles/full-dark/diff.scss
@@ -1,7 +1,7 @@
 input[type='text']:not(#cw-spoiler-input),
 input[type='search'],
 input[type='number'],
-textarea#upload-modal__description, 
+textarea[id='upload-modal__description'],
 input:not([type]) {
   background: $ui-base-color !important;
   color: $primary-text-color !important;


### PR DESCRIPTION
フルダークテーマの下記箇所を修正しています。
- `textarea[id='upload-modal__description']`
  - 投稿に添付したメディアの編集モーダルウインドウに存在する、「視覚的に閲覧が難しいユーザーへの説明」の入力エリア
  - textareaの背景色および文字色が白色のままだったため、視認性が悪かったものを修正しました。
  - 修正前：![image](https://github.com/kmycode/mastodon/assets/43964607/04a032f7-7b60-49a5-9e4d-3885593b06f6)
  - 修正後：![image](https://github.com/kmycode/mastodon/assets/43964607/5f662297-d93b-4bf8-8d0a-eb8e561ce4c1)

- `.compose-form__warning`
  - 投稿画面にて一部の公開範囲などを選んだ際に、入力欄の上部に表示される、注意書き等の表示エリア
  - 明るい背景色のため視認性が悪かったものを修正しました
  - 修正前：![image](https://github.com/kmycode/mastodon/assets/43964607/de7a644a-7ffa-42c9-b7d1-a4afde60075c)
  - 修正後：![image](https://github.com/kmycode/mastodon/assets/43964607/23418590-93e2-450f-ad2c-bd6123cffda8)
