### PR TITLE
Add: `fedibird_capabilities`に`kmyblue_server_features`

### DIFF
--- a/app/helpers/kmyblue_capabilities_helper.rb
+++ b/app/helpers/kmyblue_capabilities_helper.rb
@@ -19,6 +19,7 @@ module KmyblueCapabilitiesHelper
       kmyblue_searchability_limited
       kmyblue_circle_history
       kmyblue_list_notification
+      kmyblue_server_features
     )
 
     capabilities << :full_text_search if Chewy.enabled?


### PR DESCRIPTION
誰も投稿していないサーバーで、クライアントアプリが`account.server_features`を参照する設定項目を表示すべきか判断できるように