### PR TITLE
Add: #716 スマホで見た時、右サイドメニューの下に大きめの余白

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2984,6 +2984,10 @@ $ui-header-logo-wordmark-width: 99px;
       display: none;
     }
 
+    .navigation-panel__legal {
+      margin-bottom: 100px;
+    }
+
     .column-link__icon {
       font-size: 18px;
     }


### PR DESCRIPTION
Closes #716 