### PR TITLE
Remove: 絵文字リアクション対応サーバーに`rosekey`

### DIFF
--- a/app/models/instance_info.rb
+++ b/app/models/instance_info.rb
@@ -27,7 +27,6 @@ class InstanceInfo < ApplicationRecord
     meisskey
     misskey
     pleroma
-    rosekey
     sharkey
     tanukey
   ).freeze


### PR DESCRIPTION
Reverts kmycode/mastodon#698

当該実装が`metadata.features`に対応　https://mi.164.one/notes/9s8itn5mzv6r000c
このフォークを利用するサーバーのアップデートを待ちたいのでマージまでに少し期間を置く