### PR TITLE
Fix: モデレーターが投稿を編集するとき、編集したアカウントを保存する処理においてkmy.blueサーバー向け個別設定を削除

### DIFF
--- a/app/controllers/admin/statuses_controller.rb
+++ b/app/controllers/admin/statuses_controller.rb
@@ -125,7 +125,7 @@ module Admin
       return @edit_account_id || @account.id if @edit_account_checked
 
       @edit_account_checked = true
-      @edit_account_id = Account.local.find_by(username: 'official')&.id || @account.id
+      @edit_account_id = Account.representative.id
     end
 
     def filter_params


### PR DESCRIPTION
kmy.blueサーバーに依存する処理を削除