### PR TITLE
Fix: NodeInfoのupstreamにおけるソフトウェア名に大文字が含まれている問題

### DIFF
--- a/app/serializers/node_info/serializer.rb
+++ b/app/serializers/node_info/serializer.rb
@@ -45,7 +45,7 @@ class NodeInfo::Serializer < ActiveModel::Serializer
       nodeDescription: Setting.site_short_description,
       features: capabilities_for_nodeinfo,
       upstream: {
-        name: 'Mastodon',
+        name: 'mastodon',
         version: Mastodon::Version.to_s_of_mastodon,
       },
     }


### PR DESCRIPTION
Closes #760 