### PR TITLE
Fix: フォロワー数を隠す設定にしているアカウントのフォロワー数が一部画面で隠れない問題

### DIFF
--- a/app/javascript/mastodon/components/account.jsx
+++ b/app/javascript/mastodon/components/account.jsx
@@ -140,7 +140,8 @@ const Account = ({ size = 46, account, onFollow, onBlock, onMute, onMuteNotifica
             <DisplayName account={account} />
             {!minimal && (
               <div className='account__details'>
-                <ShortNumber value={account.get('followers_count')} renderer={FollowersCounter} /> {verification} {muteTimeRemaining}
+                <ShortNumber value={account.get('followers_count')} renderer={FollowersCounter}
+                  isHide={account.getIn(['other_settings', 'hide_followers_count'])} /> {verification} {muteTimeRemaining}
               </div>
             )}
           </div>


### PR DESCRIPTION
※このバグによってAPIからフォロワー数が取得できるわけではない。あくまで表示上「- followers」が「0 followers」となるのを直すだけなので、プライバシーの侵害にはならないです