### PR TITLE
Change: 絵文字リアクションの通知のグループ化で、アカウントを絵文字の種類ごとに表示

### DIFF
--- a/app/javascript/mastodon/api_types/notifications.ts
+++ b/app/javascript/mastodon/api_types/notifications.ts
@@ -65,6 +65,7 @@ export interface BaseNotificationJSON {
   created_at: string;
   group_key: string;
   account: ApiAccountJSON;
+  emoji_reaction?: NotifyEmojiReactionJSON;
 }
 
 export interface BaseNotificationGroupJSON {

--- a/app/javascript/mastodon/api_types/notifications.ts
+++ b/app/javascript/mastodon/api_types/notifications.ts
@@ -43,6 +43,22 @@ export type NotificationType =
   | 'admin.sign_up'
   | 'admin.report';
 
+export interface NotifyEmojiReactionJSON {
+  name: string;
+  count: number;
+  me: boolean;
+  url?: string;
+  static_url?: string;
+  domain?: string;
+  width?: number;
+  height?: number;
+}
+
+export interface NotificationEmojiReactionGroupJSON {
+  emoji_reaction: NotifyEmojiReactionJSON;
+  sample_account_ids: string[];
+}
+
 export interface BaseNotificationJSON {
   id: string;
   type: NotificationType;
@@ -60,6 +76,7 @@ export interface BaseNotificationGroupJSON {
   most_recent_notification_id: string;
   page_min_id?: string;
   page_max_id?: string;
+  emoji_reaction_groups?: NotificationEmojiReactionGroupJSON[];
 }
 
 interface NotificationGroupWithStatusJSON extends BaseNotificationGroupJSON {
@@ -70,6 +87,7 @@ interface NotificationGroupWithStatusJSON extends BaseNotificationGroupJSON {
 interface NotificationWithStatusJSON extends BaseNotificationJSON {
   type: NotificationWithStatusType;
   status: ApiStatusJSON;
+  emoji_reaction?: NotifyEmojiReactionJSON;
 }
 
 interface ReportNotificationGroupJSON extends BaseNotificationGroupJSON {

--- a/app/javascript/mastodon/features/notifications_v2/components/notification_emoji_reaction.tsx
+++ b/app/javascript/mastodon/features/notifications_v2/components/notification_emoji_reaction.tsx
@@ -32,6 +32,7 @@ export const NotificationEmojiReaction: React.FC<{
       icon={EmojiReactionIcon}
       iconId='star'
       accountIds={notification.sampleAccountIds}
+      emojiReactionGroups={notification.emojiReactionGroups}
       statusId={notification.statusId}
       timestamp={notification.latest_page_notification_at}
       count={notification.notifications_count}

--- a/app/javascript/mastodon/features/notifications_v2/components/notification_group_with_status.tsx
+++ b/app/javascript/mastodon/features/notifications_v2/components/notification_group_with_status.tsx
@@ -6,9 +6,11 @@ import { HotKeys } from 'react-hotkeys';
 
 import { replyComposeById } from 'mastodon/actions/compose';
 import { navigateToStatus } from 'mastodon/actions/statuses';
+import EmojiView from 'mastodon/components/emoji_view';
 import type { IconProp } from 'mastodon/components/icon';
 import { Icon } from 'mastodon/components/icon';
 import { RelativeTimestamp } from 'mastodon/components/relative_timestamp';
+import type { EmojiReactionGroup } from 'mastodon/models/notification_group';
 import { useAppDispatch } from 'mastodon/store';
 
 import { AvatarGroup } from './avatar_group';
@@ -26,6 +28,7 @@ export const NotificationGroupWithStatus: React.FC<{
   actions?: JSX.Element;
   count: number;
   accountIds: string[];
+  emojiReactionGroups?: EmojiReactionGroup[];
   timestamp: string;
   labelRenderer: LabelRenderer;
   labelSeeMoreHref?: string;
@@ -36,6 +39,7 @@ export const NotificationGroupWithStatus: React.FC<{
   iconId,
   timestamp,
   accountIds,
+  emojiReactionGroups,
   actions,
   count,
   statusId,
@@ -89,11 +93,28 @@ export const NotificationGroupWithStatus: React.FC<{
 
         <div className='notification-group__main'>
           <div className='notification-group__main__header'>
-            <div className='notification-group__main__header__wrapper'>
-              <AvatarGroup accountIds={accountIds} />
+            {emojiReactionGroups?.map((group) => (
+                <div key={group.emoji.name}>
+                  <div className='notification-group__main__header__wrapper__for_emoji_reaction'>
+                    <EmojiView
+                      name={group.emoji.name}
+                      url={group.emoji.url}
+                      staticUrl={group.emoji.static_url}
+                    />
+                    <AvatarGroup accountIds={group.sampleAccountIds} />
 
-              {actions}
-            </div>
+                    {actions}
+                  </div>
+                </div>
+              ))}
+
+            {!emojiReactionGroups && (
+              <div className='notification-group__main__header__wrapper'>
+                <AvatarGroup accountIds={accountIds} />
+
+                {actions}
+              </div>
+            )}
 
             <div className='notification-group__main__header__label'>
               {label}

--- a/app/javascript/mastodon/features/notifications_v2/components/notification_group_with_status.tsx
+++ b/app/javascript/mastodon/features/notifications_v2/components/notification_group_with_status.tsx
@@ -94,19 +94,19 @@ export const NotificationGroupWithStatus: React.FC<{
         <div className='notification-group__main'>
           <div className='notification-group__main__header'>
             {emojiReactionGroups?.map((group) => (
-                <div key={group.emoji.name}>
-                  <div className='notification-group__main__header__wrapper__for_emoji_reaction'>
-                    <EmojiView
-                      name={group.emoji.name}
-                      url={group.emoji.url}
-                      staticUrl={group.emoji.static_url}
-                    />
-                    <AvatarGroup accountIds={group.sampleAccountIds} />
+              <div key={group.emoji.name}>
+                <div className='notification-group__main__header__wrapper__for_emoji_reaction'>
+                  <EmojiView
+                    name={group.emoji.name}
+                    url={group.emoji.url}
+                    staticUrl={group.emoji.static_url}
+                  />
+                  <AvatarGroup accountIds={group.sampleAccountIds} />
 
-                    {actions}
-                  </div>
+                  {actions}
                 </div>
-              ))}
+              </div>
+            ))}
 
             {!emojiReactionGroups && (
               <div className='notification-group__main__header__wrapper'>

--- a/app/javascript/mastodon/reducers/notification_groups.ts
+++ b/app/javascript/mastodon/reducers/notification_groups.ts
@@ -223,18 +223,20 @@ function processNewNotification(
       )
         existingGroup.sampleAccountIds.pop();
 
-      const emojiReactionGroups = existingGroup.emoji_reaction_groups;
-      const emojiReactionData = notification.emoji_reaction;
-      if (emojiReactionGroups && emojiReactionData) {
-        const sameEmoji = emojiReactionGroups.find(
-          (g) => g.emoji_reaction.name === emojiReactionData.name,
-        );
-        if (sameEmoji) {
-          if (
-            sameEmoji.sample_account_ids.unshift(notification.account.id) >
-            NOTIFICATIONS_GROUP_MAX_AVATARS
-          )
-            sameEmoji.sample_account_ids.pop();
+      if (existingGroup.type === 'emoji_reaction') {
+        const emojiReactionGroups = existingGroup.emojiReactionGroups;
+        const emojiReactionData = notification.emoji_reaction;
+        if (emojiReactionGroups && emojiReactionData) {
+          const sameEmoji = emojiReactionGroups.find(
+            (g) => g.emoji.name === emojiReactionData.name,
+          );
+          if (sameEmoji) {
+            if (
+              sameEmoji.sampleAccountIds.unshift(notification.account.id) >
+              NOTIFICATIONS_GROUP_MAX_AVATARS
+            )
+              sameEmoji.sampleAccountIds.pop();
+          }
         }
       }
 

--- a/app/javascript/mastodon/reducers/notification_groups.ts
+++ b/app/javascript/mastodon/reducers/notification_groups.ts
@@ -227,8 +227,9 @@ function processNewNotification(
 
             if (sameEmoji) {
               if (
+                !sameEmoji.sampleAccountIds.includes(notification.account.id) &&
                 sameEmoji.sampleAccountIds.unshift(notification.account.id) >
-                NOTIFICATIONS_GROUP_MAX_AVATARS
+                  NOTIFICATIONS_GROUP_MAX_AVATARS
               )
                 sameEmoji.sampleAccountIds.pop();
 

--- a/app/javascript/mastodon/reducers/notification_groups.ts
+++ b/app/javascript/mastodon/reducers/notification_groups.ts
@@ -225,6 +225,11 @@ function processNewNotification(
               NOTIFICATIONS_GROUP_MAX_AVATARS
             )
               sameEmoji.sampleAccountIds.pop();
+          } else {
+            emojiReactionGroups.unshift({
+              emoji: emojiReactionData,
+              sampleAccountIds: [notification.account.id],
+            });
           }
         }
       }

--- a/app/javascript/mastodon/reducers/notification_groups.ts
+++ b/app/javascript/mastodon/reducers/notification_groups.ts
@@ -223,6 +223,21 @@ function processNewNotification(
       )
         existingGroup.sampleAccountIds.pop();
 
+      const emojiReactionGroups = existingGroup.emoji_reaction_groups;
+      const emojiReactionData = notification.emoji_reaction;
+      if (emojiReactionGroups && emojiReactionData) {
+        const sameEmoji = emojiReactionGroups.find(
+          (g) => g.emoji_reaction.name === emojiReactionData.name,
+        );
+        if (sameEmoji) {
+          if (
+            sameEmoji.sample_account_ids.unshift(notification.account.id) >
+            NOTIFICATIONS_GROUP_MAX_AVATARS
+          )
+            sameEmoji.sample_account_ids.pop();
+        }
+      }
+
       existingGroup.most_recent_notification_id = notification.id;
       existingGroup.page_max_id = notification.id;
       existingGroup.latest_page_notification_at = notification.created_at;

--- a/app/javascript/mastodon/reducers/notification_groups.ts
+++ b/app/javascript/mastodon/reducers/notification_groups.ts
@@ -212,19 +212,29 @@ function processNewNotification(
     const existingGroup = groups[existingGroupIndex];
 
     if (existingGroup && existingGroup.type !== 'gap') {
+      // Update emoji reaction emoji groups
       if (existingGroup.type === 'emoji_reaction') {
         const emojiReactionGroups = existingGroup.emojiReactionGroups;
         const emojiReactionData = notification.emoji_reaction;
+
         if (emojiReactionGroups && emojiReactionData) {
-          const sameEmoji = emojiReactionGroups.find(
+          const sameEmojiIndex = emojiReactionGroups.findIndex(
             (g) => g.emoji.name === emojiReactionData.name,
           );
-          if (sameEmoji) {
-            if (
-              sameEmoji.sampleAccountIds.unshift(notification.account.id) >
-              NOTIFICATIONS_GROUP_MAX_AVATARS
-            )
-              sameEmoji.sampleAccountIds.pop();
+
+          if (sameEmojiIndex > -1) {
+            const sameEmoji = emojiReactionGroups[sameEmojiIndex];
+
+            if (sameEmoji) {
+              if (
+                sameEmoji.sampleAccountIds.unshift(notification.account.id) >
+                NOTIFICATIONS_GROUP_MAX_AVATARS
+              )
+                sameEmoji.sampleAccountIds.pop();
+
+              emojiReactionGroups.splice(sameEmojiIndex, 1);
+              emojiReactionGroups.unshift(sameEmoji);
+            }
           } else {
             emojiReactionGroups.unshift({
               emoji: emojiReactionData,

--- a/app/javascript/mastodon/reducers/notification_groups.ts
+++ b/app/javascript/mastodon/reducers/notification_groups.ts
@@ -211,18 +211,7 @@ function processNewNotification(
   if (existingGroupIndex > -1) {
     const existingGroup = groups[existingGroupIndex];
 
-    if (
-      existingGroup &&
-      existingGroup.type !== 'gap' &&
-      !existingGroup.sampleAccountIds.includes(notification.account.id) // This can happen for example if you like, then unlike, then like again the same post
-    ) {
-      // Update the existing group
-      if (
-        existingGroup.sampleAccountIds.unshift(notification.account.id) >
-        NOTIFICATIONS_GROUP_MAX_AVATARS
-      )
-        existingGroup.sampleAccountIds.pop();
-
+    if (existingGroup && existingGroup.type !== 'gap') {
       if (existingGroup.type === 'emoji_reaction') {
         const emojiReactionGroups = existingGroup.emojiReactionGroups;
         const emojiReactionData = notification.emoji_reaction;
@@ -239,6 +228,19 @@ function processNewNotification(
           }
         }
       }
+    }
+
+    if (
+      existingGroup &&
+      existingGroup.type !== 'gap' &&
+      !existingGroup.sampleAccountIds.includes(notification.account.id) // This can happen for example if you like, then unlike, then like again the same post
+    ) {
+      // Update the existing group
+      if (
+        existingGroup.sampleAccountIds.unshift(notification.account.id) >
+        NOTIFICATIONS_GROUP_MAX_AVATARS
+      )
+        existingGroup.sampleAccountIds.pop();
 
       existingGroup.most_recent_notification_id = notification.id;
       existingGroup.page_max_id = notification.id;

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -10907,6 +10907,25 @@ noscript {
       &__wrapper {
         display: flex;
         justify-content: space-between;
+
+        &__for_emoji_reaction {
+          display: flex;
+          justify-content: start;
+
+          .emoji {
+            display: inline-block;
+            width: 40px;
+            align-self: center;
+
+            img {
+              height: 20px;
+            }
+          }
+
+          .notification-group__avatar-group {
+            margin-left: 8px;
+          }
+        }
       }
 
       &__label {

--- a/app/models/notification_group.rb
+++ b/app/models/notification_group.rb
@@ -5,6 +5,7 @@ class NotificationGroup < ActiveModelSerializers::Model
 
   # Try to keep this consistent with `app/javascript/mastodon/models/notification_group.ts`
   SAMPLE_ACCOUNTS_SIZE = 8
+  SAMPLE_ACCOUNTS_SIZE_FOR_EMOJI_REACTION = 24
 
   class NotificationEmojiReactionGroup < ActiveModelSerializers::Model
     attributes :emoji_reaction, :sample_accounts
@@ -20,7 +21,9 @@ class NotificationGroup < ActiveModelSerializers::Model
       most_recent_notifications = scope.order(id: :desc).includes(:from_account).take(SAMPLE_ACCOUNTS_SIZE)
       most_recent_id = most_recent_notifications.first.id
       sample_accounts = most_recent_notifications.map(&:from_account)
-      emoji_reaction_groups = extract_emoji_reaction_pair(scope.includes(:emoji_reaction))
+      emoji_reaction_groups = extract_emoji_reaction_pair(
+        scope.order(id: :desc).includes(emoji_reaction: :account).take(SAMPLE_ACCOUNTS_SIZE_FOR_EMOJI_REACTION)
+      )
       notifications_count = scope.count
     else
       most_recent_id = notification.id

--- a/app/models/notification_group.rb
+++ b/app/models/notification_group.rb
@@ -5,7 +5,7 @@ class NotificationGroup < ActiveModelSerializers::Model
 
   # Try to keep this consistent with `app/javascript/mastodon/models/notification_group.ts`
   SAMPLE_ACCOUNTS_SIZE = 8
-  SAMPLE_ACCOUNTS_SIZE_FOR_EMOJI_REACTION = 24
+  SAMPLE_ACCOUNTS_SIZE_FOR_EMOJI_REACTION = 40
 
   class NotificationEmojiReactionGroup < ActiveModelSerializers::Model
     attributes :emoji_reaction, :sample_accounts

--- a/app/models/notification_group.rb
+++ b/app/models/notification_group.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
 class NotificationGroup < ActiveModelSerializers::Model
-  attributes :group_key, :sample_accounts, :notifications_count, :notification, :most_recent_notification_id
+  attributes :group_key, :sample_accounts, :notifications_count, :notification, :most_recent_notification_id, :emoji_reaction_groups
 
   # Try to keep this consistent with `app/javascript/mastodon/models/notification_group.ts`
   SAMPLE_ACCOUNTS_SIZE = 8
+
+  class NotificationEmojiReactionGroup < ActiveModelSerializers::Model
+    attributes :emoji_reaction, :sample_accounts
+  end
 
   def self.from_notification(notification, max_id: nil)
     if notification.group_key.present?
@@ -16,10 +20,12 @@ class NotificationGroup < ActiveModelSerializers::Model
       most_recent_notifications = scope.order(id: :desc).includes(:from_account).take(SAMPLE_ACCOUNTS_SIZE)
       most_recent_id = most_recent_notifications.first.id
       sample_accounts = most_recent_notifications.map(&:from_account)
+      emoji_reaction_groups = extract_emoji_reaction_pair(scope.includes(:emoji_reaction))
       notifications_count = scope.count
     else
       most_recent_id = notification.id
       sample_accounts = [notification.from_account]
+      emoji_reaction_groups = extract_emoji_reaction_pair([notification])
       notifications_count = 1
     end
 
@@ -27,6 +33,7 @@ class NotificationGroup < ActiveModelSerializers::Model
       notification: notification,
       group_key: notification.group_key || "ungrouped-#{notification.id}",
       sample_accounts: sample_accounts,
+      emoji_reaction_groups: emoji_reaction_groups,
       notifications_count: notifications_count,
       most_recent_notification_id: most_recent_id
     )
@@ -38,4 +45,16 @@ class NotificationGroup < ActiveModelSerializers::Model
            :account_relationship_severance_event,
            :account_warning,
            to: :notification, prefix: false
+
+  def self.extract_emoji_reaction_pair(scope)
+    scope = scope.filter { |g| g.emoji_reaction.present? }
+
+    return [] if scope.empty?
+    return [] unless scope.first.type == :emoji_reaction
+
+    scope
+      .each_with_object({}) { |e, h| h[e.emoji_reaction.name] = (h[e.emoji_reaction.name] || []).push(e.emoji_reaction) }
+      .to_a
+      .map { |pair| NotificationEmojiReactionGroup.new(emoji_reaction: pair[1].first, sample_accounts: pair[1].take(SAMPLE_ACCOUNTS_SIZE).map(&:account)) }
+  end
 end

--- a/app/serializers/rest/notification_group_serializer.rb
+++ b/app/serializers/rest/notification_group_serializer.rb
@@ -30,6 +30,10 @@ class REST::NotificationGroupSerializer < ActiveModel::Serializer
     object.type == :'admin.report'
   end
 
+  def emoji_reaction_type?
+    object.type == :emoji_reaction
+  end
+
   def relationship_severance_event?
     object.type == :severed_relationships
   end
@@ -56,4 +60,15 @@ class REST::NotificationGroupSerializer < ActiveModel::Serializer
   def paginated?
     !instance_options[:group_metadata].nil?
   end
+
+  class NotificationEmojiReactionGroupSerializer < ActiveModel::Serializer
+    has_one :emoji_reaction, serializer: REST::NotifyEmojiReactionSerializer
+    attribute :sample_account_ids
+
+    def sample_account_ids
+      object.sample_accounts.pluck(:id).map(&:to_s)
+    end
+  end
+
+  has_many :emoji_reaction_groups, each_serializer: NotificationEmojiReactionGroupSerializer, if: :emoji_reaction_type?
 end

--- a/app/serializers/rest/notify_emoji_reaction_serializer.rb
+++ b/app/serializers/rest/notify_emoji_reaction_serializer.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class REST::NotifyEmojiReactionSerializer < ActiveModel::Serializer
+  # Please update app/javascript/api_types/notification.ts when making changes to the attributes
   include RoutingHelper
 
   attributes :name

--- a/spec/models/notification_group_spec.rb
+++ b/spec/models/notification_group_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe NotificationGroup do
+  subject { described_class.from_notification(notification) }
+
+  context 'when emoji reaction notifications' do
+    let(:target_status)  { Fabricate(:status) }
+    let(:alice)          { Fabricate(:account) }
+    let(:bob)            { Fabricate(:account) }
+    let(:ohagi)          { Fabricate(:account) }
+    let(:custom_emoji)   { Fabricate(:custom_emoji) }
+    let(:emoji_reaction) { Fabricate(:emoji_reaction, account: alice, status: target_status, name: custom_emoji.shortcode, custom_emoji: custom_emoji) }
+    let(:notification)   { Fabricate(:notification, account: target_status.account, activity: emoji_reaction, group_key: group_key) }
+    let(:group_key)      { 5 }
+
+    it 'with single emoji_reaction' do
+      group = subject.emoji_reaction_groups.first
+
+      expect(group).to_not be_nil
+      expect(group.emoji_reaction.id).to eq emoji_reaction.id
+      expect(group.sample_accounts.map(&:id)).to contain_exactly(alice.id)
+    end
+
+    it 'with multiple reactions' do
+      second = Fabricate(:emoji_reaction, account: bob, status: target_status, name: custom_emoji.shortcode, custom_emoji: custom_emoji)
+      Fabricate(:notification, account: target_status.account, activity: second, group_key: group_key)
+
+      group = subject.emoji_reaction_groups.first
+
+      expect(group).to_not be_nil
+      expect([emoji_reaction.id, second.id]).to include group.emoji_reaction.id
+      expect(group.sample_accounts.map(&:id)).to contain_exactly(alice.id, bob.id)
+    end
+
+    it 'with multiple reactions and multiple emojis' do
+      second = Fabricate(:emoji_reaction, account: bob, status: target_status, name: custom_emoji.shortcode, custom_emoji: custom_emoji)
+      Fabricate(:notification, account: target_status.account, activity: second, group_key: group_key)
+      third = Fabricate(:emoji_reaction, account: ohagi, status: target_status, name: '😀')
+      Fabricate(:notification, account: target_status.account, activity: third, group_key: group_key)
+
+      group = subject.emoji_reaction_groups.find { |g| g.emoji_reaction.name == custom_emoji.shortcode }
+      second_group = subject.emoji_reaction_groups.find { |g| g.emoji_reaction.name == '😀' }
+
+      expect(group).to_not be_nil
+      expect([emoji_reaction.id, second.id]).to include group.emoji_reaction.id
+      expect(group.sample_accounts.map(&:id)).to contain_exactly(alice.id, bob.id)
+
+      expect(second_group).to_not be_nil
+      expect(third.id).to eq second_group.emoji_reaction.id
+      expect(second_group.sample_accounts.map(&:id)).to contain_exactly(ohagi.id)
+    end
+  end
+end


### PR DESCRIPTION
- [x] すでにつけられたものとは異なる絵文字リアクション通知をストリーミングで受け取った場合、新しいグループを作って反映する処理
- [x] 新しくつけられた絵文字の行を一番上に移動する
- [x] 絵文字リアクション通知において、１投稿に含めるアカウント数を16からさらに増やす
- [x] 余計な負荷がないか、N+1問題の点検