### PR TITLE
Change: #844 `searchableBy`に意図しない値が入っていたときの挙動

### DIFF
--- a/app/lib/activitypub/parser/status_parser.rb
+++ b/app/lib/activitypub/parser/status_parser.rb
@@ -147,7 +147,7 @@ class ActivityPub::Parser::StatusParser
   def audience_searchable_by
     return nil if @object['searchableBy'].nil?
 
-    @audience_searchable_by = as_array(@object['searchableBy']).map { |x| value_or_id(x) }
+    @audience_searchable_by = as_array(@object['searchableBy']).map { |x| value_or_id(x) }.compact_blank
   end
 
   def summary_language_map?
@@ -204,17 +204,18 @@ class ActivityPub::Parser::StatusParser
 
   def searchability_from_audience
     return nil if audience_searchable_by.blank?
+    return :limited if audience_searchable_by.include?('kmyblue:Limited') || audience_searchable_by.include?('as:Limited')
 
     if audience_searchable_by.any? { |uri| ActivityPub::TagManager.instance.public_collection?(uri) }
       :public
-    elsif audience_searchable_by.include?('kmyblue:Limited') || audience_searchable_by.include?('as:Limited')
-      :limited
     elsif audience_searchable_by.include?('kmyblue:LocalPublic') && @friend
       :public_unlisted
     elsif audience_searchable_by.include?(@account.followers_url)
       :private
     elsif audience_searchable_by.include?(@account.uri) || audience_searchable_by.include?(@account.url)
       :direct
+    else
+      :limited
     end
   end
 end

--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -278,7 +278,7 @@ class ActivityPub::ProcessAccountService < BaseService
   def audience_searchable_by
     return nil if @json['searchableBy'].nil?
 
-    @audience_searchable_by_processaccountservice = as_array(@json['searchableBy']).map { |x| value_or_id(x) }
+    @audience_searchable_by_processaccountservice = as_array(@json['searchableBy']).map { |x| value_or_id(x) }.compact_blank
   end
 
   def searchability_from_audience
@@ -289,14 +289,16 @@ class ActivityPub::ProcessAccountService < BaseService
       return invalid_subscription_software? ? misskey_searchability_from_indexable : :direct
     end
 
+    return :limited if audience_searchable_by.include?('kmyblue:Limited') || audience_searchable_by.include?('as:Limited')
+
     if audience_searchable_by.any? { |uri| ActivityPub::TagManager.instance.public_collection?(uri) }
       :public
     elsif audience_searchable_by.include?(@account.followers_url)
       :private
-    elsif audience_searchable_by.include?('kmyblue:Limited') || audience_searchable_by.include?('as:Limited')
-      :limited
-    else
+    elsif audience_searchable_by.include?(@account.uri) || audience_searchable_by.include?(@account.url)
       :direct
+    else
+      :limited
     end
   end
 

--- a/spec/lib/activitypub/activity/create_spec.rb
+++ b/spec/lib/activitypub/activity/create_spec.rb
@@ -653,6 +653,17 @@ RSpec.describe ActivityPub::Activity::Create do
           end
         end
 
+        context 'with unintended value' do
+          let(:searchable_by) { 'ohagi' }
+
+          it 'create status' do
+            status = sender.statuses.first
+
+            expect(status).to_not be_nil
+            expect(status.searchability).to eq 'limited'
+          end
+        end
+
         context 'with direct when not specify' do
           let(:searchable_by) { nil }
 
@@ -666,17 +677,6 @@ RSpec.describe ActivityPub::Activity::Create do
 
         context 'with limited' do
           let(:searchable_by) { 'kmyblue:Limited' }
-
-          it 'create status' do
-            status = sender.statuses.first
-
-            expect(status).to_not be_nil
-            expect(status.searchability).to eq 'limited'
-          end
-        end
-
-        context 'with limited old spec' do
-          let(:searchable_by) { 'as:Limited' }
 
           it 'create status' do
             status = sender.statuses.first

--- a/spec/services/activitypub/process_account_service_spec.rb
+++ b/spec/services/activitypub/process_account_service_spec.rb
@@ -165,19 +165,19 @@ RSpec.describe ActivityPub::ProcessAccountService do
       end
     end
 
-    context 'when limited old spec' do
-      let(:searchable_by) { 'as:Limited' }
-
-      it 'searchability is limited' do
-        expect(subject.searchability).to eq 'limited'
-      end
-    end
-
     context 'when empty array' do
       let(:searchable_by) { '' }
 
       it 'searchability is direct' do
         expect(subject.searchability).to eq 'direct'
+      end
+    end
+
+    context 'when unintended value' do
+      let(:searchable_by) { 'ohagi' }
+
+      it 'searchability is direct' do
+        expect(subject.searchability).to eq 'limited'
       end
     end
 


### PR DESCRIPTION
Closes #844 