### PR TITLE
Fix: #484 `docker-compose.yml`をフォークでも利用できるよう修正

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
   web:
     # You can uncomment the following line if you want to not use the prebuilt image, for example if you have local code changes
     build: .
-    # image: ghcr.io/mastodon/mastodon:v4.3.0-rc.1
+    image: kmyblue:15.0-lts
     restart: always
     env_file: .env.production
     command: bundle exec puma -C config/puma.rb
@@ -83,7 +83,7 @@ services:
     build:
       dockerfile: ./streaming/Dockerfile
       context: .
-    # image: ghcr.io/mastodon/mastodon-streaming:v4.3.0-rc.1
+    image: kmyblue-streaming:15.0-lts
     restart: always
     env_file: .env.production
     command: node ./streaming/index.js
@@ -101,7 +101,7 @@ services:
 
   sidekiq:
     build: .
-    image: ghcr.io/mastodon/mastodon:v4.3.0-rc.1
+    image: kmyblue:15.0-lts
     restart: always
     env_file: .env.production
     command: bundle exec sidekiq

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,8 +58,8 @@ services:
 
   web:
     # You can uncomment the following line if you want to not use the prebuilt image, for example if you have local code changes
-    # build: .
-    image: ghcr.io/mastodon/mastodon:v4.3.0-rc.1
+    build: .
+    # image: ghcr.io/mastodon/mastodon:v4.3.0-rc.1
     restart: always
     env_file: .env.production
     command: bundle exec puma -C config/puma.rb
@@ -80,10 +80,10 @@ services:
 
   streaming:
     # You can uncomment the following lines if you want to not use the prebuilt image, for example if you have local code changes
-    # build:
-    #   dockerfile: ./streaming/Dockerfile
-    #   context: .
-    image: ghcr.io/mastodon/mastodon-streaming:v4.3.0-rc.1
+    build:
+      dockerfile: ./streaming/Dockerfile
+      context: .
+    # image: ghcr.io/mastodon/mastodon-streaming:v4.3.0-rc.1
     restart: always
     env_file: .env.production
     command: node ./streaming/index.js

--- a/lib/mastodon/version.rb
+++ b/lib/mastodon/version.rb
@@ -6,6 +6,8 @@ module Mastodon
 
     module_function
 
+    # If you change the version number, also change the image version in docker-compose.yml.
+
     def kmyblue_major
       15
     end


### PR DESCRIPTION
関連: #484 