### PR TITLE
Fix: #870 フォロワー数を公開しない設定にしているアカウントからフォローされたときの通知に「0フォロワー」と表示される

### DIFF
--- a/app/javascript/mastodon/features/notifications_v2/components/notification_follow.tsx
+++ b/app/javascript/mastodon/features/notifications_v2/components/notification_follow.tsx
@@ -37,8 +37,14 @@ const FollowerCount: React.FC<{ accountId: string }> = ({ accountId }) => {
 
   if (!account) return null;
 
+  const isHide = account.other_settings.hide_followers_count;
+
   return (
-    <ShortNumber value={account.followers_count} renderer={FollowersCounter} />
+    <ShortNumber
+      value={account.followers_count}
+      renderer={FollowersCounter}
+      isHide={isHide}
+    />
   );
 };
 


### PR DESCRIPTION
Closes #870 