### PR TITLE
Fix: `%`を含む利用規約やプライバシーポリシーを設定した場合、REST APIからの取得ができなくなる問題

### DIFF
--- a/app/serializers/rest/privacy_policy_serializer.rb
+++ b/app/serializers/rest/privacy_policy_serializer.rb
@@ -8,7 +8,7 @@ class REST::PrivacyPolicySerializer < ActiveModel::Serializer
   end
 
   def content
-    markdown.render(format(object.text, domain: Rails.configuration.x.local_domain))
+    markdown.render(object.text.gsub(/%{domain}/, Rails.configuration.x.local_domain))
   end
 
   private


### PR DESCRIPTION
この解決方法に自信がないので本家へのPRはしません
誰かRubyに詳しい人PRお願いします

英語だと問題にならないだろうけど、日本語圏（おそらく韓国語、中国語でも）だとURLに%が入ることがあります