### PR TITLE
Fix: #981 ログイン時にカスタムCSSが無条件で無効化されてしまう

### DIFF
--- a/app/controllers/auth/sessions_controller.rb
+++ b/app/controllers/auth/sessions_controller.rb
@@ -174,7 +174,7 @@ class Auth::SessionsController < Devise::SessionsController
   end
 
   def disable_custom_css?
-    user_params[:disable_css].present? && user_params[:disable_css] != '0'
+    user_params[:disable_css].present? && user_params[:disable_css] == '1'
   end
 
   def disable_custom_css!(user)


### PR DESCRIPTION
Closes #981 