### PR TITLE
Fix: WebUIでTL表示が「不明なエラーが発生しました」になる問題を修正

### DIFF
--- a/app/javascript/mastodon/actions/importer/index.js
+++ b/app/javascript/mastodon/actions/importer/index.js
@@ -50,14 +50,14 @@ export function importFetchedStatus(status, options = {}) {
   return importFetchedStatuses([status], options);
 }
 
-export function importFetchedStatuses(statuses) {
+export function importFetchedStatuses(statuses, options = {}) {
   return (dispatch, getState) => {
     const accounts = [];
     const normalStatuses = [];
     const polls = [];
     const filters = [];
 
-    function processStatus(status, options = undefined) {
+    function processStatus(status) {
       pushUnique(normalStatuses, normalizeStatus(status, getState().getIn(['statuses', status.id]), options));
       pushUnique(accounts, status.account);
 


### PR DESCRIPTION
本家 9dbebbb2ee9c00490f0cf7e4e8f5c076055496b8 にて`app/javascript/mastodon/actions/importer/index.js`と`app/javascript/mastodon/actions/importer/normalizer.js`にそれぞれ`options`引数が追加されました

kmyblueでは 976b107ea3e3e3a6ae1261ad8f2d31e89af2840b にて、以前より`options`引数を入れていましたが、今回本家で追加されたものとは型が違いました。

この状態で `index.js`の`importFetchedStatuses` のみ以前の状態となっていたため、optionsが存在しなかった時のデフォルト値`undefine`が格納された状態だと、分割代入に失敗しエラーとなっていました。

![](https://mstdn.yuicho.net/system/media_attachments/files/115/546/543/378/768/157/original/d69d1f60455181ad.png)

なお、optionsの定義場所も変わっていますが、これは本家に合わせた変更です。